### PR TITLE
Update InfoResp

### DIFF
--- a/responses.go
+++ b/responses.go
@@ -34,7 +34,7 @@ type InfoResp struct {
 	HeadBlockTime            JSONTime    `json:"head_block_time"`             //  "2018-02-02T04:19:32"
 	HeadBlockProducer        AccountName `json:"head_block_producer"`         // "inita"
 
-	VirtualBlockCPULimit uint64 `json:"virtual_block_cpu_limit"`
+	VirtualBlockCPULimit string `json:"virtual_block_cpu_limit"`
 	VirtualBlockNetLimit uint64 `json:"virtual_block_net_limit"`
 	BlockCPULimit        uint64 `json:"block_cpu_limit"`
 	BlockNetLimit        uint64 `json:"block_net_limit"`


### PR DESCRIPTION
There get the "virtual_block_cpu_limit" is string from Dawn 4.1 by get info.
So, change the virtual_block_cpu_limit to string.