### PR TITLE
system: register updateauth action on init

### DIFF
--- a/system/init.go
+++ b/system/init.go
@@ -28,6 +28,7 @@ func init() {
 	eos.RegisterAction(AN("eosio"), ActN("canceldelay"), CancelDelay{})
 	eos.RegisterAction(AN("eosio"), ActN("bidname"), Bidname{})
 	// eos.RegisterAction(AN("eosio"), ActN("nonce"), &Nonce{})
+	eos.RegisterAction(AN("eosio"), ActN("updateauth"), UpdateAuth{})
 }
 
 var AN = eos.AN


### PR DESCRIPTION
For some reason `UpdateAuth` action isn't registered on init