### PR TITLE
Add wallet-url configuration individually

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-ENUMIVO API library for Go
-==========================
-Based on [eos-go](https://github.com/eoscanada/eos-go)
+EOS.IO API library for Go
+=========================
+
+[![GoDoc](https://godoc.org/github.com/eoscanada/eos-go?status.svg)](https://godoc.org/github.com/eoscanada/eos-go)
 
 This library provides simple access to data structures (binary packing
 and JSON interface) and API calls to an EOS.IO RPC server, running
@@ -51,3 +52,13 @@ License
 -------
 
 MIT
+
+
+
+
+TODO notes
+----------
+
+Changes to dawn4:
+* sig_digest always adds something even with empty context free actions.
+* PUB, PVT, SIG

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-EOS.IO API library for Go
-=========================
-
-[![GoDoc](https://godoc.org/github.com/eoscanada/eos-go?status.svg)](https://godoc.org/github.com/eoscanada/eos-go)
+ENUMIVO API library for Go
+==========================
+Based on [eos-go](https://github.com/eoscanada/eos-go)
 
 This library provides simple access to data structures (binary packing
 and JSON interface) and API calls to an EOS.IO RPC server, running
@@ -52,13 +51,3 @@ License
 -------
 
 MIT
-
-
-
-
-TODO notes
-----------
-
-Changes to dawn4:
-* sig_digest always adds something even with empty context free actions.
-* PUB, PVT, SIG

--- a/api.go
+++ b/api.go
@@ -106,6 +106,10 @@ func (api *API) SetSigner(s Signer) {
 	api.Signer = s
 }
 
+func (api *API) SetWalletUrl(walletUrl string) {
+	api.WalletURL = walletUrl
+}
+
 // ProducerPause will pause block production on a nodeos with
 // `producer_api` plugin loaded.
 func (api *API) ProducerPause() error {
@@ -411,7 +415,10 @@ func (api *API) call(baseAPI string, endpoint string, body interface{}, out inte
 	}
 
 	var targetURL string
-	if baseAPI == "wallet" && api.WalletURL != "" {
+	if baseAPI == "wallet" {
+		if api.WalletURL == "" {
+			return fmt.Errorf("WalletURL: %s while calling wallet API", ErrNotSet)
+		}
 		targetURL = fmt.Sprintf("%s/v1/%s/%s", api.WalletURL, baseAPI, endpoint)
 	} else {
 		targetURL = fmt.Sprintf("%s/v1/%s/%s", api.BaseURL, baseAPI, endpoint)
@@ -466,6 +473,7 @@ func (api *API) call(baseAPI string, endpoint string, body interface{}, out inte
 }
 
 var ErrNotFound = errors.New("resource not found")
+var ErrNotSet = errors.New("config is not set")
 
 type M map[string]interface{}
 

--- a/api.go
+++ b/api.go
@@ -20,6 +20,7 @@ import (
 type API struct {
 	HttpClient              *http.Client
 	BaseURL                 string
+	WalletURL               string
 	Signer                  Signer
 	Debug                   bool
 	Compress                CompressionType
@@ -409,7 +410,13 @@ func (api *API) call(baseAPI string, endpoint string, body interface{}, out inte
 		return err
 	}
 
-	targetURL := fmt.Sprintf("%s/v1/%s/%s", api.BaseURL, baseAPI, endpoint)
+	var targetURL string
+	if baseAPI == "wallet" && api.WalletURL != "" {
+		targetURL = fmt.Sprintf("%s/v1/%s/%s", api.WalletURL, baseAPI, endpoint)
+	} else {
+		targetURL = fmt.Sprintf("%s/v1/%s/%s", api.BaseURL, baseAPI, endpoint)
+	}
+
 	req, err := http.NewRequest("POST", targetURL, jsonBody)
 	if err != nil {
 		return fmt.Errorf("NewRequest: %s", err)

--- a/api.go
+++ b/api.go
@@ -342,11 +342,6 @@ func (api *API) GetProducers() (out *ProducersResp, err error) {
 	return
 }
 
-func (api *API) GetAbiBinToJson(code AccountName, action ActionName, binargs string,) (out interface{}, err error) {
-	err = api.call("chain", "abi_bin_to_json", M{"code": code,"action": action, "binargs": binargs}, &out)
-	return
-}
-
 func (api *API) GetBlockByNum(num uint32) (out *BlockResp, err error) {
 	err = api.call("chain", "get_block", M{"block_num_or_id": fmt.Sprintf("%d", num)}, &out)
 	//err = api.call("chain", "get_block", M{"block_num_or_id": num}, &out)

--- a/api.go
+++ b/api.go
@@ -342,6 +342,11 @@ func (api *API) GetProducers() (out *ProducersResp, err error) {
 	return
 }
 
+func (api *API) GetAbiBinToJson(code AccountName, action ActionName, binargs string,) (out interface{}, err error) {
+	err = api.call("chain", "abi_bin_to_json", M{"code": code,"action": action, "binargs": binargs}, &out)
+	return
+}
+
 func (api *API) GetBlockByNum(num uint32) (out *BlockResp, err error) {
 	err = api.call("chain", "get_block", M{"block_num_or_id": fmt.Sprintf("%d", num)}, &out)
 	//err = api.call("chain", "get_block", M{"block_num_or_id": num}, &out)


### PR DESCRIPTION
added `WalletURL` in API struct.
modified call method in api.go to call wallet service separately.
```
var targetURL string
if baseAPI == "wallet" && api.WalletURL != "" {
	targetURL = fmt.Sprintf("%s/v1/%s/%s", api.WalletURL, baseAPI, endpoint)
} else {
	targetURL = fmt.Sprintf("%s/v1/%s/%s", api.BaseURL, baseAPI, endpoint)
}
```

Maybe its an optional change for security reasons.