### PR TITLE
Fix bug of transaction id calculation

### DIFF
--- a/api.go
+++ b/api.go
@@ -367,6 +367,11 @@ func (api *API) GetTransaction(id string) (out *TransactionResp, err error) {
 	return
 }
 
+func (api *API) GetTransactionWithBlockNumHint(id string, num uint32) (out *TransactionResp, err error) {
+	err = api.call("history", "get_transaction", M{"id": id, "block_num_hint": num}, &out)
+	return
+}
+
 func (api *API) GetTransactionRaw(id string) (out json.RawMessage, err error) {
 	err = api.call("history", "get_transaction", M{"id": id}, &out)
 	return

--- a/transaction.go
+++ b/transaction.go
@@ -201,7 +201,16 @@ type PackedTransaction struct {
 
 func (p *PackedTransaction) ID() SHA256Bytes {
 	h := sha256.New()
-	_, _ = h.Write(p.PackedTransaction)
+
+	switch p.Compression {
+	case CompressionZlib:
+		r, _ := zlib.NewReader(bytes.NewBuffer(p.PackedTransaction))
+		d, _ := ioutil.ReadAll(r)
+		_, _ = h.Write(d)
+	case CompressionNone:
+		_, _ = h.Write(p.PackedTransaction)
+	}
+
 	return h.Sum(nil)
 }
 


### PR DESCRIPTION
Transaction id is calculate by packed transaction, before which we should unpack first. There is a case that the transaction is compressed by zlib, we need to decompress it to get the correct data.

reference: [packed_transaction::id()](https://github.com/EOSIO/eos/blob/master/libraries/chain/transaction.cpp#L295)

Another change is the new get_transaction api can support a block_num_hint parameter, I add this api for easy to use.
