### PR TITLE
Implemented `get_code_hash` API call

### DIFF
--- a/api.go
+++ b/api.go
@@ -135,6 +135,16 @@ func (api *API) GetCode(account AccountName) (out *GetCodeResp, err error) {
 	return
 }
 
+func (api *API) GetCodeHash(account AccountName) (out SHA256Bytes, err error) {
+	resp := GetCodeHashResp{}
+	if err = api.call("chain", "get_code_hash", M{"account_name": account}, &resp); err != nil {
+		return
+	}
+
+	buffer, err := hex.DecodeString(resp.CodeHash)
+	return SHA256Bytes(buffer), err
+}
+
 func (api *API) GetABI(account AccountName) (out *GetABIResp, err error) {
 	err = api.call("chain", "get_abi", M{"account_name": account}, &out)
 	return

--- a/types.go
+++ b/types.go
@@ -336,6 +336,11 @@ type GetCodeResp struct {
 	ABI         ABI         `json:"abi"`
 }
 
+type GetCodeHashResp struct {
+	AccountName AccountName `json:"account_name"`
+	CodeHash    string      `json:"code_hash"`
+}
+
 type GetABIResp struct {
 	AccountName AccountName `json:"account_name"`
 	ABI         ABI         `json:"abi"`


### PR DESCRIPTION
This might not be available yet through all API nodes as this was not released yet to an official release.

Fixes #50