### PR TITLE
Fixed ProducerKey using an incorrect JSON key

### DIFF
--- a/p2ptypes.go
+++ b/p2ptypes.go
@@ -213,7 +213,7 @@ type RegionSummary struct {
 }
 
 type ProducerKey struct {
-	AccountName     AccountName   `json:"account_name"`
+	AccountName     AccountName   `json:"producer_name"`
 	BlockSigningKey ecc.PublicKey `json:"block_signing_key"`
 }
 


### PR DESCRIPTION
Quick little fix here. As per [producer_schedule.hpp](https://github.com/EOSIO/eos/blob/master/libraries/chain/include/eosio/chain/producer_schedule.hpp) the account name is stored as and serializes into `producer_name` rather than `account_name`.