### PR TITLE
add chain id and peer param to eos-p2p-client cmd

### DIFF
--- a/cmd/eos-p2p-client/main.go
+++ b/cmd/eos-p2p-client/main.go
@@ -10,19 +10,20 @@ import (
 )
 
 var peer = flag.String("peer", "localhost:9876", "peer to connect to")
+var chainID = flag.String("chain-id", "cf057bbfb72640471fd910bcb67639c22df9f92470936cddc1ade0e2f2e7dc4f", "net chainID to connect to")
 
 func main() {
 	flag.Parse()
 
-	cID, err := hex.DecodeString("cf057bbfb72640471fd910bcb67639c22df9f92470936cddc1ade0e2f2e7dc4f")
+	cID, err := hex.DecodeString(*chainID)
 	if err != nil {
 
 		log.Fatal(err)
 	}
 
-	fmt.Println("P2P Client", *peer)
+	fmt.Println("P2P Client ", *peer, " With Chain ID :", *chainID)
 	client := p2p.NewClient(
-		p2p.NewOutgoingPeer("localhost:9876", "eos-proxy", &p2p.HandshakeInfo{
+		p2p.NewOutgoingPeer(*peer, "eos-proxy", &p2p.HandshakeInfo{
 			ChainID:      cID,
 			HeadBlockNum: 1,
 		}),


### PR DESCRIPTION
eos-p2p-client not finish the flags to start client, sometimes we will use this cmd to test some p2p function on testnet, so we need set chain-id and p2p peer to start client.