### PR TITLE
Hide p2p debug output, and use logger to log

### DIFF
--- a/cmd/eos-p2p-client/main.go
+++ b/cmd/eos-p2p-client/main.go
@@ -11,13 +11,18 @@ import (
 
 var peer = flag.String("peer", "localhost:9876", "peer to connect to")
 var chainID = flag.String("chain-id", "cf057bbfb72640471fd910bcb67639c22df9f92470936cddc1ade0e2f2e7dc4f", "net chainID to connect to")
+var showLog = flag.Bool("v", false, "show detail log")
 
 func main() {
 	flag.Parse()
 
+	if *showLog {
+		p2p.EnableP2PLogging()
+	}
+	defer p2p.SyncLogger()
+
 	cID, err := hex.DecodeString(*chainID)
 	if err != nil {
-
 		log.Fatal(err)
 	}
 

--- a/cmd/eos-p2p-proxy/main.go
+++ b/cmd/eos-p2p-proxy/main.go
@@ -12,12 +12,18 @@ import (
 var peer1 = flag.String("peer1", "localhost:9876", "peer 1")
 var peer2 = flag.String("peer2", "localhost:2222", "peer 2")
 var chainID = flag.String("chain-id", "308cae83a690640be3726a725dde1fa72a845e28cfc63f28c3fa0a6ccdb6faf0", "peer 1")
+var showLog = flag.Bool("v", false, "show detail log")
 
 func main() {
+	flag.Parse()
 
 	fmt.Println("P2P Proxy")
 
-	flag.Parse()
+	if *showLog {
+		p2p.EnableP2PLogging()
+	}
+	defer p2p.SyncLogger()
+
 	cID, err := hex.DecodeString(*chainID)
 	if err != nil {
 		log.Fatal(err)

--- a/cmd/eos-p2p-relay/main.go
+++ b/cmd/eos-p2p-relay/main.go
@@ -10,14 +10,17 @@ import (
 
 var peer = flag.String("peer", "", "peer")
 var listeningAddress = flag.String("listening-address", "", "address on with the relay will listen")
+var showLog = flag.Bool("v", false, "show detail log")
 
 func main() {
-
 	flag.Parse()
 
+	if *showLog {
+		p2p.EnableP2PLogging()
+	}
+	defer p2p.SyncLogger()
+
 	relay := p2p.NewRelay(*listeningAddress, *peer)
-
 	relay.RegisterHandler(p2p.StringLoggerHandler)
-
 	fmt.Println(relay.Start())
 }

--- a/logger.go
+++ b/logger.go
@@ -42,3 +42,8 @@ func newLogger(production bool) (l *zap.Logger) {
 	}
 	return
 }
+
+// NewLogger a wrap to newLogger
+func NewLogger(production bool) *zap.Logger {
+	return newLogger(production)
+}

--- a/p2p/client.go
+++ b/p2p/client.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"math"
 
+	"go.uber.org/zap"
+
 	"time"
 
 	"github.com/eoscanada/eos-go"
@@ -70,7 +72,7 @@ func (c *Client) read(peer *Peer, errChannel chan error) {
 					errChannel <- fmt.Errorf("HandshakeMessage: %s", err)
 					break
 				}
-				logger.Debug("Handshake resent!")
+				p2pLog.Debug("Handshake resent", zap.String("other", m.P2PAddress))
 
 			} else {
 
@@ -101,7 +103,7 @@ func (c *Client) read(peer *Peer, errChannel chan error) {
 				if c.catchup.requestedEndBlock == blockNum {
 
 					if c.catchup.originHeadBlock <= blockNum {
-						logger.Debug("In sync with last handshake")
+						p2pLog.Debug("In sync with last handshake")
 						blockID, err := m.BlockID()
 						if err != nil {
 							errChannel <- fmt.Errorf("getting block id: %s", err)
@@ -110,7 +112,8 @@ func (c *Client) read(peer *Peer, errChannel chan error) {
 						peer.handshakeInfo.HeadBlockID = blockID
 						peer.handshakeInfo.HeadBlockTime = m.SignedBlockHeader.Timestamp.Time
 						peer.SendHandshake(peer.handshakeInfo)
-						logger.Debug("Sent new handshake with info:", peer.handshakeInfo)
+						p2pLog.Debug("Send new handshake",
+							zap.Object("handshakeInfo", peer.handshakeInfo))
 					} else {
 						err = c.catchup.sendSyncRequest(peer)
 						if err != nil {
@@ -124,11 +127,9 @@ func (c *Client) read(peer *Peer, errChannel chan error) {
 }
 
 func (c *Client) Start() error {
-
-	logger.Info("Starting client")
+	p2pLog.Info("Starting client")
 
 	errorChannel := make(chan error, 1)
-
 	readyChannel := c.peer.Connect(errorChannel)
 
 	for {
@@ -143,7 +144,7 @@ func (c *Client) Start() error {
 				}
 			}
 		case err := <-errorChannel:
-			logger.Error("Start got ERROR:", err)
+			logErr("Start Err", err)
 			return err
 		}
 	}
@@ -166,8 +167,9 @@ func (c *Catchup) sendSyncRequest(peer *Peer) error {
 	c.requestedStartBlock = c.headBlock
 	c.requestedEndBlock = c.headBlock + uint32(math.Min(float64(delta), 100))
 
-	logger.Debugf("Sending sync request to origin: start block [%d] end block [%d]",
-		c.requestedStartBlock, c.requestedEndBlock)
+	p2pLog.Debug("Sending sync request",
+		zap.Uint32("startBlock", c.requestedStartBlock),
+		zap.Uint32("endBlock", c.requestedEndBlock))
 
 	err := peer.SendSyncRequest(c.requestedStartBlock, c.requestedEndBlock+1)
 

--- a/p2p/handler.go
+++ b/p2p/handler.go
@@ -2,7 +2,6 @@ package p2p
 
 import (
 	"encoding/json"
-	"fmt"
 )
 
 type Handler interface {
@@ -19,18 +18,18 @@ func (f HandlerFunc) Handle(envelope *Envelope) {
 var LoggerHandler = HandlerFunc(func(envelope *Envelope) {
 	data, err := json.Marshal(envelope)
 	if err != nil {
-		fmt.Println("logger plugin err: ", err)
+		logger.Error("logger plugin err: ", err)
 		return
 	}
 
-	fmt.Println("logger - message : ", string(data))
+	logger.Info("logger - message : ", string(data))
 })
 
 // StringLoggerHandler simply prints the messages as they go through the client.
 var StringLoggerHandler = HandlerFunc(func(envelope *Envelope) {
 	name, _ := envelope.Packet.Type.Name()
-	fmt.Printf(
-		"type %s from %s to %s: %s\n",
+	logger.Infof(
+		"type %s from %s to %s: %s",
 		name,
 		envelope.Sender.Address,
 		envelope.Receiver.Address,

--- a/p2p/handler.go
+++ b/p2p/handler.go
@@ -2,6 +2,8 @@ package p2p
 
 import (
 	"encoding/json"
+
+	"go.uber.org/zap"
 )
 
 type Handler interface {
@@ -18,21 +20,21 @@ func (f HandlerFunc) Handle(envelope *Envelope) {
 var LoggerHandler = HandlerFunc(func(envelope *Envelope) {
 	data, err := json.Marshal(envelope)
 	if err != nil {
-		logger.Error("logger plugin err: ", err)
+		logErr("Marshal err", err)
 		return
 	}
 
-	logger.Info("logger - message : ", string(data))
+	p2pLog.Info("handler", zap.String("message", string(data)))
 })
 
 // StringLoggerHandler simply prints the messages as they go through the client.
 var StringLoggerHandler = HandlerFunc(func(envelope *Envelope) {
 	name, _ := envelope.Packet.Type.Name()
-	logger.Infof(
-		"type %s from %s to %s: %s",
-		name,
-		envelope.Sender.Address,
-		envelope.Receiver.Address,
-		envelope.Packet.P2PMessage,
+	p2pLog.Info(
+		"handler Packet",
+		zap.String("name", name),
+		zap.String("sender", envelope.Sender.Address),
+		zap.String("receiver", envelope.Receiver.Address),
+		zap.Stringer("msg", envelope.Packet.P2PMessage), // this will use by String()
 	)
 })

--- a/p2p/logger.go
+++ b/p2p/logger.go
@@ -1,72 +1,33 @@
 package p2p
 
-import "go.uber.org/zap"
+import (
+	"fmt"
 
-// SugaredLoggerInterface a interface for zap sugared logger,
-// use this can allow some project based on eos-go use it's different logger imp
-type SugaredLoggerInterface interface {
+	eos "github.com/eoscanada/eos-go"
+	"go.uber.org/zap"
+)
 
-	// From zap/sugar.go just same as zap 's SugaredLogger
-
-	// Debug uses fmt.Sprint to construct and log a message.
-	Debug(args ...interface{})
-
-	// Info uses fmt.Sprint to construct and log a message.
-	Info(args ...interface{})
-
-	// Warn uses fmt.Sprint to construct and log a message.
-	Warn(args ...interface{})
-
-	// Error uses fmt.Sprint to construct and log a message.
-	Error(args ...interface{})
-
-	// DPanic uses fmt.Sprint to construct and log a message. In development, the
-	// logger then panics. (See DPanicLevel for details.)
-	DPanic(args ...interface{})
-
-	// Panic uses fmt.Sprint to construct and log a message, then panics.
-	Panic(args ...interface{})
-
-	// Fatal uses fmt.Sprint to construct and log a message, then calls os.Exit.
-	Fatal(args ...interface{})
-
-	// Debugf uses fmt.Sprintf to log a templated message.
-	Debugf(template string, args ...interface{})
-
-	// Infof uses fmt.Sprintf to log a templated message.
-	Infof(template string, args ...interface{})
-
-	// Warnf uses fmt.Sprintf to log a templated message.
-	Warnf(template string, args ...interface{})
-
-	// Errorf uses fmt.Sprintf to log a templated message.
-	Errorf(template string, args ...interface{})
-
-	// DPanicf uses fmt.Sprintf to log a templated message. In development, the
-	// logger then panics. (See DPanicLevel for details.)
-	DPanicf(template string, args ...interface{})
-
-	// Panicf uses fmt.Sprintf to log a templated message, then panics.
-	Panicf(template string, args ...interface{})
-
-	// Fatalf uses fmt.Sprintf to log a templated message, then calls os.Exit.
-	Fatalf(template string, args ...interface{})
-
-	// Sync flushes any buffered log entries.
-	Sync() error
-}
+// Just Use same patterns to eos-go/logger.go
+// TODO be improved in terms of external package integration for logger by eos-go
 
 // logger default use nil zap logger
-var logger SugaredLoggerInterface = zap.NewNop().Sugar()
+var p2pLog = zap.NewNop()
 
-// SetLogger set logger for p2p
-func SetLogger(l SugaredLoggerInterface) {
-	logger = l
+// EnableP2PLogging enable p2p package to log by zap
+func EnableP2PLogging() {
+	p2pLog = eos.NewLogger(false)
 }
 
-// SyncLogger sync logger if it is no nil
+// logErr log err msg by p2pLog
+func logErr(msg string, err error) {
+	p2pLog.Error(msg, zap.Error(err))
+}
+
+// SyncLogger sync logger, should `defer SyncLogger()` when use p2p package
 func SyncLogger() {
-	if logger != nil {
-		logger.Sync()
+	err := p2pLog.Sync()
+	if err != nil {
+		// logger is err, log by fmt
+		fmt.Printf("err by sync p2p logger %s", err.Error())
 	}
 }

--- a/p2p/logger.go
+++ b/p2p/logger.go
@@ -1,0 +1,72 @@
+package p2p
+
+import "go.uber.org/zap"
+
+// SugaredLoggerInterface a interface for zap sugared logger,
+// use this can allow some project based on eos-go use it's different logger imp
+type SugaredLoggerInterface interface {
+
+	// From zap/sugar.go just same as zap 's SugaredLogger
+
+	// Debug uses fmt.Sprint to construct and log a message.
+	Debug(args ...interface{})
+
+	// Info uses fmt.Sprint to construct and log a message.
+	Info(args ...interface{})
+
+	// Warn uses fmt.Sprint to construct and log a message.
+	Warn(args ...interface{})
+
+	// Error uses fmt.Sprint to construct and log a message.
+	Error(args ...interface{})
+
+	// DPanic uses fmt.Sprint to construct and log a message. In development, the
+	// logger then panics. (See DPanicLevel for details.)
+	DPanic(args ...interface{})
+
+	// Panic uses fmt.Sprint to construct and log a message, then panics.
+	Panic(args ...interface{})
+
+	// Fatal uses fmt.Sprint to construct and log a message, then calls os.Exit.
+	Fatal(args ...interface{})
+
+	// Debugf uses fmt.Sprintf to log a templated message.
+	Debugf(template string, args ...interface{})
+
+	// Infof uses fmt.Sprintf to log a templated message.
+	Infof(template string, args ...interface{})
+
+	// Warnf uses fmt.Sprintf to log a templated message.
+	Warnf(template string, args ...interface{})
+
+	// Errorf uses fmt.Sprintf to log a templated message.
+	Errorf(template string, args ...interface{})
+
+	// DPanicf uses fmt.Sprintf to log a templated message. In development, the
+	// logger then panics. (See DPanicLevel for details.)
+	DPanicf(template string, args ...interface{})
+
+	// Panicf uses fmt.Sprintf to log a templated message, then panics.
+	Panicf(template string, args ...interface{})
+
+	// Fatalf uses fmt.Sprintf to log a templated message, then calls os.Exit.
+	Fatalf(template string, args ...interface{})
+
+	// Sync flushes any buffered log entries.
+	Sync() error
+}
+
+// logger default use nil zap logger
+var logger SugaredLoggerInterface = zap.NewNop().Sugar()
+
+// SetLogger set logger for p2p
+func SetLogger(l SugaredLoggerInterface) {
+	logger = l
+}
+
+// SyncLogger sync logger if it is no nil
+func SyncLogger() {
+	if logger != nil {
+		logger.Sync()
+	}
+}

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -8,6 +8,10 @@ import (
 	"net"
 	"time"
 
+	"go.uber.org/zap"
+
+	"go.uber.org/zap/zapcore"
+
 	"runtime"
 
 	"bufio"
@@ -30,6 +34,14 @@ type Peer struct {
 	cancelHandshakeTimeout chan bool
 }
 
+// MarshalLogObject calls the underlying function from zap.
+func (p Peer) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddString("name", p.Name)
+	enc.AddString("address", p.Address)
+	enc.AddString("agent", p.agent)
+	return enc.AddObject("handshakeInfo", p.handshakeInfo)
+}
+
 type HandshakeInfo struct {
 	ChainID                  eos.Checksum256
 	HeadBlockNum             uint32
@@ -41,6 +53,17 @@ type HandshakeInfo struct {
 
 func (h *HandshakeInfo) String() string {
 	return fmt.Sprintf("Handshake Info: HeadBlockNum [%d], LastIrreversibleBlockNum [%d]", h.HeadBlockNum, h.LastIrreversibleBlockNum)
+}
+
+// MarshalLogObject calls the underlying function from zap.
+func (h HandshakeInfo) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddString("chainID", h.ChainID.String())
+	enc.AddUint32("headBlockNum", h.HeadBlockNum)
+	enc.AddString("headBlockID", h.HeadBlockID.String())
+	enc.AddTime("headBlockTime", h.HeadBlockTime)
+	enc.AddUint32("lastIrreversibleBlockNum", h.LastIrreversibleBlockNum)
+	enc.AddString("lastIrreversibleBlockID", h.LastIrreversibleBlockID.String())
+	return nil
 }
 
 func (p *Peer) SetHandshakeTimeout(timeout time.Duration) {
@@ -76,7 +99,7 @@ func (p *Peer) Read() (*eos.Packet, error) {
 		p.cancelHandshakeTimeout <- true
 	}
 	if err != nil {
-		logger.Error("Connection Read error:", p.Address, err)
+		p2pLog.Error("Connection Read Err", zap.String("address", p.Address), zap.Error(err))
 		return nil, fmt.Errorf("connection: read: %s", err)
 	}
 	return packet, nil
@@ -101,20 +124,22 @@ func (p *Peer) Connect(errChan chan error) (ready chan bool) {
 
 	ready = make(chan bool, 1)
 	go func() {
+		address2log := zap.String("address", p.Address)
+
 		if p.listener {
-			logger.Debug("Listening on:", p.Address)
+			p2pLog.Debug("Listening on", address2log)
 
 			ln, err := net.Listen("tcp", p.Address)
 			if err != nil {
 				errChan <- fmt.Errorf("peer init: listening %s: %s", p.Address, err)
 			}
 
-			logger.Debug("Accepting connection on:", p.Address)
+			p2pLog.Debug("Accepting connection on", address2log)
 			conn, err := ln.Accept()
 			if err != nil {
 				errChan <- fmt.Errorf("peer init: accepting connection on %s: %s", p.Address, err)
 			}
-			logger.Debug("Connected on:", p.Address)
+			p2pLog.Debug("Connected on", address2log)
 
 			p.SetConnection(conn)
 			ready <- true
@@ -124,15 +149,15 @@ func (p *Peer) Connect(errChan chan error) (ready chan bool) {
 				go func(p *Peer) {
 					select {
 					case <-time.After(p.handshakeTimeout):
-						logger.Warn("Handshake took too long:", p.Address)
+						p2pLog.Warn("handshake took too long", address2log)
 						errChan <- fmt.Errorf("handshake took too long: %s", p.Address)
 					case <-p.cancelHandshakeTimeout:
-						logger.Warn("cancelHandshakeTimeout canceled:", p.Address)
+						p2pLog.Warn("cancelHandshakeTimeout canceled", address2log)
 					}
 				}(p)
 			}
 
-			logger.Infof("Dialing: %s, timeout: %d", p.Address, p.connectionTimeout)
+			p2pLog.Info("Dialing", address2log, zap.Duration("timeout", p.connectionTimeout))
 			conn, err := net.DialTimeout("tcp", p.Address, p.connectionTimeout)
 			if err != nil {
 				if p.handshakeTimeout > 0 {
@@ -141,7 +166,7 @@ func (p *Peer) Connect(errChan chan error) (ready chan bool) {
 				errChan <- fmt.Errorf("peer init: dial %s: %s", p.Address, err)
 				return
 			}
-			logger.Info("Connected to:", p.Address)
+			p2pLog.Info("Connected to", address2log)
 			p.connection = conn
 			p.reader = bufio.NewReader(conn)
 			ready <- true
@@ -170,7 +195,11 @@ func (p *Peer) WriteP2PMessage(message eos.P2PMessage) (err error) {
 }
 
 func (p *Peer) SendSyncRequest(startBlockNum uint32, endBlockNumber uint32) (err error) {
-	logger.Debugf("SendSyncRequest start [%d] end [%d]", startBlockNum, endBlockNumber)
+	p2pLog.Debug("SendSyncRequest",
+		zap.String("peer", p.Address),
+		zap.Uint32("start", startBlockNum),
+		zap.Uint32("end", endBlockNumber))
+
 	syncRequest := &eos.SyncRequestMessage{
 		StartBlock: startBlockNum,
 		EndBlock:   endBlockNumber,
@@ -179,7 +208,11 @@ func (p *Peer) SendSyncRequest(startBlockNum uint32, endBlockNumber uint32) (err
 	return p.WriteP2PMessage(syncRequest)
 }
 func (p *Peer) SendRequest(startBlockNum uint32, endBlockNumber uint32) (err error) {
-	logger.Debugf("SendRequest start [%d] end [%d]", startBlockNum, endBlockNumber)
+	p2pLog.Debug("SendRequest",
+		zap.String("peer", p.Address),
+		zap.Uint32("start", startBlockNum),
+		zap.Uint32("end", endBlockNumber))
+
 	request := &eos.RequestMessage{
 		ReqTrx: eos.OrderedBlockIDs{
 			Mode:    [4]byte{0, 0, 0, 0},
@@ -195,7 +228,11 @@ func (p *Peer) SendRequest(startBlockNum uint32, endBlockNumber uint32) (err err
 }
 
 func (p *Peer) SendNotice(headBlockNum uint32, libNum uint32, mode byte) (err error) {
-	logger.Debugf("Send Notice head [%d] lib [%d] type[%d]", headBlockNum, libNum, mode)
+	p2pLog.Debug("Send Notice",
+		zap.String("peer", p.Address),
+		zap.Uint32("head", headBlockNum),
+		zap.Uint32("lib", libNum),
+		zap.Uint8("type", mode))
 
 	notice := &eos.NoticeMessage{
 		KnownTrx: eos.OrderedBlockIDs{
@@ -211,7 +248,7 @@ func (p *Peer) SendNotice(headBlockNum uint32, libNum uint32, mode byte) (err er
 }
 
 func (p *Peer) SendTime() (err error) {
-	logger.Debug("SendTime")
+	p2pLog.Debug("SendTime", zap.String("peer", p.Address))
 
 	notice := &eos.TimeMessage{}
 	return p.WriteP2PMessage(notice)
@@ -221,10 +258,12 @@ func (p *Peer) SendHandshake(info *HandshakeInfo) (err error) {
 
 	publicKey, err := ecc.NewPublicKey("EOS1111111111111111111111111111111114T1Anm")
 	if err != nil {
-		logger.Error("publicKey err by : ", err)
+		logErr("publicKey err", err)
 		err = fmt.Errorf("sending handshake to %s: create public key: %s", p.Address, err)
 		return
 	}
+
+	p2pLog.Debug("SendHandshake", zap.String("peer", p.Address), zap.Object("info", info))
 
 	tstamp := eos.Tstamp{Time: info.HeadBlockTime}
 

--- a/p2p/proxy.go
+++ b/p2p/proxy.go
@@ -3,8 +3,6 @@ package p2p
 import (
 	"fmt"
 
-	"log"
-
 	"github.com/eoscanada/eos-go"
 )
 
@@ -34,9 +32,9 @@ func (p *Proxy) RegisterHandlers(handlers []Handler) {
 func (p *Proxy) read(sender *Peer, receiver *Peer, errChannel chan error) {
 	for {
 
-		log.Println("Waiting for packet")
+		logger.Debug("Waiting for packet")
 		packet, err := sender.Read()
-		log.Println("Received for packet")
+		logger.Debug("Received for packet")
 		if err != nil {
 			errChannel <- fmt.Errorf("read message from %s: %s", sender.Address, err)
 			return
@@ -70,13 +68,13 @@ func (p *Proxy) handle(packet *eos.Packet, sender *Peer, receiver *Peer) error {
 }
 
 func triggerHandshake(peer *Peer) error {
-	fmt.Printf("Sending handshake [%s] to: %s\n", peer.handshakeInfo, peer.Address)
+	logger.Debugf("Sending handshake [%s] to: %s", peer.handshakeInfo, peer.Address)
 	return peer.SendHandshake(peer.handshakeInfo)
 }
 
 func (p *Proxy) ConnectAndStart() error {
 
-	log.Println("Connecting and starting proxy")
+	logger.Info("Connecting and starting proxy")
 
 	errorChannel := make(chan error)
 
@@ -106,7 +104,7 @@ func (p *Proxy) ConnectAndStart() error {
 
 func (p *Proxy) Start() error {
 
-	log.Println("Starting readers")
+	logger.Info("Starting readers")
 	errorChannel := make(chan error)
 	go p.read(p.Peer1, p.Peer2, errorChannel)
 	go p.read(p.Peer2, p.Peer1, errorChannel)
@@ -119,6 +117,6 @@ func (p *Proxy) Start() error {
 		}
 	}
 
-	log.Println("Started")
+	logger.Info("Started")
 	return <-errorChannel
 }

--- a/p2p/proxy.go
+++ b/p2p/proxy.go
@@ -3,6 +3,8 @@ package p2p
 import (
 	"fmt"
 
+	"go.uber.org/zap"
+
 	"github.com/eoscanada/eos-go"
 )
 
@@ -32,9 +34,9 @@ func (p *Proxy) RegisterHandlers(handlers []Handler) {
 func (p *Proxy) read(sender *Peer, receiver *Peer, errChannel chan error) {
 	for {
 
-		logger.Debug("Waiting for packet")
+		//p2pLog.Debug("Waiting for packet")
 		packet, err := sender.Read()
-		logger.Debug("Received for packet")
+		//p2pLog.Debug("Received for packet")
 		if err != nil {
 			errChannel <- fmt.Errorf("read message from %s: %s", sender.Address, err)
 			return
@@ -68,13 +70,12 @@ func (p *Proxy) handle(packet *eos.Packet, sender *Peer, receiver *Peer) error {
 }
 
 func triggerHandshake(peer *Peer) error {
-	logger.Debugf("Sending handshake [%s] to: %s", peer.handshakeInfo, peer.Address)
 	return peer.SendHandshake(peer.handshakeInfo)
 }
 
 func (p *Proxy) ConnectAndStart() error {
 
-	logger.Info("Connecting and starting proxy")
+	p2pLog.Info("Connecting and starting proxy")
 
 	errorChannel := make(chan error)
 
@@ -103,8 +104,9 @@ func (p *Proxy) ConnectAndStart() error {
 }
 
 func (p *Proxy) Start() error {
-
-	logger.Info("Starting readers")
+	p2pLog.Info("Starting readers",
+		zap.String("peer1", p.Peer1.Address),
+		zap.String("peer1", p.Peer2.Address))
 	errorChannel := make(chan error)
 	go p.read(p.Peer1, p.Peer2, errorChannel)
 	go p.read(p.Peer2, p.Peer1, errorChannel)
@@ -117,6 +119,6 @@ func (p *Proxy) Start() error {
 		}
 	}
 
-	logger.Info("Started")
+	//p2pLog.Info("Started")
 	return <-errorChannel
 }

--- a/p2p/utils.go
+++ b/p2p/utils.go
@@ -2,13 +2,12 @@ package p2p
 
 import (
 	"encoding/hex"
-	"fmt"
 )
 
 func DecodeHex(hexString string) (data []byte) {
 	data, err := hex.DecodeString(hexString)
 	if err != nil {
-		fmt.Println("decodeHex error: ", err)
+		logger.Error("decodeHex error: ", err)
 	}
 	return data
 }

--- a/p2p/utils.go
+++ b/p2p/utils.go
@@ -7,7 +7,7 @@ import (
 func DecodeHex(hexString string) (data []byte) {
 	data, err := hex.DecodeString(hexString)
 	if err != nil {
-		logger.Error("decodeHex error: ", err)
+		logErr("decodeHexErr", err)
 	}
 	return data
 }

--- a/p2ptypes.go
+++ b/p2ptypes.go
@@ -439,3 +439,11 @@ type PackedTransactionMessage struct {
 func (m *PackedTransactionMessage) GetType() P2PMessageType {
 	return PackedTransactionMessageType
 }
+
+func (m PackedTransactionMessage) String() string {
+	signTrx, err := m.Unpack()
+	if err != nil {
+		return fmt.Sprintf("err trx msg unpack by %s", err.Error())
+	}
+	return signTrx.String()
+}

--- a/p2ptypes.go
+++ b/p2ptypes.go
@@ -12,6 +12,7 @@ import (
 )
 
 type P2PMessage interface {
+	fmt.Stringer
 	GetType() P2PMessageType
 }
 


### PR DESCRIPTION
fix #20 Hide debug output from p2p sub-package
delete all print in p2p package
add a logger interface base on zap.SugaredLogger to p2p,
then use logger to log, this can allow developer use some other logger in project base on eos-go/p2p  