### PR TITLE
Fixed encoding/decoding binary form for public keys

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -33,7 +33,8 @@ var TypeSize = struct {
 	Checksum160    int
 	Checksum256    int
 	Checksum512    int
-	PublicKey      int
+	PublicKeyK1    int
+	PublicKeyR1    int
 	Signature      int
 	Tstamp         int
 	BlockTimestamp int
@@ -53,7 +54,8 @@ var TypeSize = struct {
 	Checksum160:    20,
 	Checksum256:    32,
 	Checksum512:    64,
-	PublicKey:      34,
+	PublicKeyK1:    34,
+	PublicKeyR1:    38,
 	Signature:      66,
 	Tstamp:         8,
 	BlockTimestamp: 4,
@@ -640,21 +642,38 @@ func (d *Decoder) ReadChecksum512() (out Checksum512, err error) {
 }
 
 func (d *Decoder) ReadPublicKey() (out ecc.PublicKey, err error) {
-
-	if d.remaining() < TypeSize.PublicKey {
-		err = fmt.Errorf("publicKey required [%d] bytes, remaining [%d]", TypeSize.PublicKey, d.remaining())
+	if d.remaining() < 1 {
+		err = fmt.Errorf("publicKey required [1] byte to read curve ID, remaining [%d]", d.remaining())
 		return
 	}
-	keyContent := make([]byte, 34)
-	copy(keyContent, d.data[d.pos:d.pos+TypeSize.PublicKey])
+
+	curve := ecc.CurveID(d.data[d.pos])
+	switch curve {
+	case ecc.CurveK1:
+		return d.readPublicKey("K1", TypeSize.PublicKeyK1)
+	case ecc.CurveR1:
+		return d.readPublicKey("R1", TypeSize.PublicKeyR1)
+	default:
+		return out, fmt.Errorf("publicKey unsupported curve prefix %q", curve)
+	}
+}
+
+func (d *Decoder) readPublicKey(curveName string, keyTypeSize int) (out ecc.PublicKey, err error) {
+	if d.remaining() < keyTypeSize {
+		err = fmt.Errorf("publicKey %s required [%d] bytes, remaining [%d]", curveName, keyTypeSize, d.remaining())
+		return
+	}
+
+	keyContent := make([]byte, keyTypeSize)
+	copy(keyContent, d.data[d.pos:d.pos+keyTypeSize])
 
 	out, err = ecc.NewPublicKeyFromData(keyContent)
 	if err != nil {
-		err = fmt.Errorf("publicKey: key from data: %s", err)
+		err = fmt.Errorf("publicKey %s: key from data: %s", curveName, err)
 	}
 
-	d.pos += TypeSize.PublicKey
-	decoderLog.Debug("read public key", zap.Stringer("pubkey", out))
+	d.pos += keyTypeSize
+	decoderLog.Debug("read public key", zap.String("curveName", curveName), zap.Stringer("pubkey", out))
 	return
 }
 

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -250,6 +250,38 @@ func TestDecoder_PublicKey(t *testing.T) {
 	assert.Equal(t, 0, d.remaining())
 }
 
+func TestDecoder_PublicKey_K1(t *testing.T) {
+	pk := ecc.MustNewPublicKey("PUB_K1_1111111111111111111111111111111114T1Anm")
+
+	buf := new(bytes.Buffer)
+	enc := NewEncoder(buf)
+	assert.NoError(t, enc.writePublicKey(pk))
+
+	d := NewDecoder(buf.Bytes())
+
+	rpk, err := d.ReadPublicKey()
+	assert.NoError(t, err)
+
+	assert.Equal(t, pk, rpk)
+	assert.Equal(t, 0, d.remaining())
+}
+
+func TestDecoder_PublicKey_R1(t *testing.T) {
+	pk := ecc.MustNewPublicKey("PUB_R1_81x8BXgDQGTWmcAaavfCDcVTTyzz1BeBYbje9yJomVMCJZbz86")
+
+	buf := new(bytes.Buffer)
+	enc := NewEncoder(buf)
+	assert.NoError(t, enc.writePublicKey(pk))
+
+	d := NewDecoder(buf.Bytes())
+
+	rpk, err := d.ReadPublicKey()
+	assert.NoError(t, err)
+
+	assert.Equal(t, pk, rpk)
+	assert.Equal(t, 0, d.remaining())
+}
+
 func TestDecoder_Empty_PublicKey(t *testing.T) {
 
 	pk := ecc.PublicKey{Curve: ecc.CurveK1, Content: []byte{}}
@@ -572,7 +604,16 @@ func TestDecoder_readUint16_missing_data(t *testing.T) {
 	assert.EqualError(t, err, "checksum 256 required [32] bytes, remaining [0]")
 
 	_, err = NewDecoder([]byte{}).ReadPublicKey()
-	assert.EqualError(t, err, "publicKey required [34] bytes, remaining [0]")
+	assert.EqualError(t, err, "publicKey required [1] byte to read curve ID, remaining [0]")
+
+	_, err = NewDecoder([]byte{0x00}).ReadPublicKey()
+	assert.EqualError(t, err, "publicKey K1 required [34] bytes, remaining [1]")
+
+	_, err = NewDecoder([]byte{0x01}).ReadPublicKey()
+	assert.EqualError(t, err, "publicKey R1 required [38] bytes, remaining [1]")
+
+	_, err = NewDecoder([]byte{0x02}).ReadPublicKey()
+	assert.EqualError(t, err, `publicKey unsupported curve prefix "UN"`)
 
 	_, err = NewDecoder([]byte{}).ReadSignature()
 	assert.EqualError(t, err, "signature required [66] bytes, remaining [0]")

--- a/ecc/pubkey.go
+++ b/ecc/pubkey.go
@@ -29,13 +29,19 @@ type PublicKey struct {
 }
 
 func NewPublicKeyFromData(data []byte) (out PublicKey, err error) {
-	if len(data) != 34 {
-		return out, fmt.Errorf("public key data must have a length of 33 ")
+	byteCount := len(data)
+	if byteCount < 34 {
+		return out, fmt.Errorf("public key data must have a length of at least 34 bytes")
+	}
+
+	curve := CurveID(data[0])
+	if curve == CurveR1 && byteCount != 38 {
+		return out, fmt.Errorf("public key R1 data must have a length of 38 bytes")
 	}
 
 	out = PublicKey{
-		Curve:   CurveID(data[0]), // 1 byte
-		Content: data[1:],         // 33 bytes
+		Curve:   curve,
+		Content: data[1:],
 	}
 
 	switch out.Curve {
@@ -69,6 +75,7 @@ func NewPublicKey(pubKey string) (out PublicKey, err error) {
 
 	if strings.HasPrefix(pubKey, PublicKeyR1Prefix) {
 		pubKeyMaterial := pubKey[len(PublicKeyR1Prefix):] // strip "PUB_R1_"
+		curveID = CurveR1
 		decodedPubKey = base58.Decode(pubKeyMaterial)
 		inner = &innerR1PublicKey{}
 	} else if strings.HasPrefix(pubKey, PublicKeyK1Prefix) {

--- a/encoder.go
+++ b/encoder.go
@@ -363,8 +363,12 @@ func (e *Encoder) writeChecksum512(checksum Checksum512) error {
 
 func (e *Encoder) writePublicKey(pk ecc.PublicKey) (err error) {
 	encoderLog.Debug("write public key", zap.Stringer("pubkey", pk))
-	if len(pk.Content) != 33 {
-		return fmt.Errorf("public key %q should be 33 bytes, was %d", hex.EncodeToString(pk.Content), len(pk.Content))
+	if pk.Curve == ecc.CurveK1 && len(pk.Content) != 33 {
+		return fmt.Errorf("public key K1 %q should be 33, was %d", hex.EncodeToString(pk.Content), len(pk.Content))
+	}
+
+	if pk.Curve == ecc.CurveR1 && len(pk.Content) != 37 {
+		return fmt.Errorf("public key R1 %q should be 37, was %d", hex.EncodeToString(pk.Content), len(pk.Content))
 	}
 
 	if err = e.writeByte(byte(pk.Curve)); err != nil {


### PR DESCRIPTION
The R1 public key was not handled correctly when encoding/decoding it to its binary form. The R1 key used 37 bytes of storage while the K1 is using 33 bytes (both uses 1 byte for the curve ID).

This commit fixes all this by adding proper support for encoding/decoding of R1 public keys.