### PR TITLE
P2p better err handle

### DIFF
--- a/p2p/client.go
+++ b/p2p/client.go
@@ -148,8 +148,7 @@ func (c *Client) Start() error {
 				}
 			}
 		case err := <-errorChannel:
-			logErr("Start Err", err)
-			return err
+			return errors.Wrap(err, "start client")
 		}
 	}
 }

--- a/p2p/client.go
+++ b/p2p/client.go
@@ -174,12 +174,6 @@ func (c *Catchup) sendSyncRequest(peer *Peer) error {
 		zap.Uint32("startBlock", c.requestedStartBlock),
 		zap.Uint32("endBlock", c.requestedEndBlock))
 
-	err := peer.SendSyncRequest(c.requestedStartBlock, c.requestedEndBlock+1)
-
-	if err != nil {
-		return errors.Wrap(err, "send sync request")
-	}
-
-	return nil
-
+	return errors.Wrapf(peer.SendSyncRequest(c.requestedStartBlock, c.requestedEndBlock+1),
+		"send sync request to %s", peer.Address)
 }

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -102,7 +102,7 @@ func (p *Peer) Read() (*eos.Packet, error) {
 	}
 	if err != nil {
 		p2pLog.Error("Connection Read Err", zap.String("address", p.Address), zap.Error(err))
-		return nil, errors.Wrap(err, "connection: read")
+		return nil, errors.Wrapf(err, "connection: read %s err", p.Address)
 	}
 	return packet, nil
 }
@@ -260,7 +260,6 @@ func (p *Peer) SendHandshake(info *HandshakeInfo) (err error) {
 
 	publicKey, err := ecc.NewPublicKey("EOS1111111111111111111111111111111114T1Anm")
 	if err != nil {
-		logErr("publicKey err", err)
 		err = errors.Wrapf(err, "sending handshake to %s: create public key", p.Address)
 		return
 	}

--- a/p2p/proxy.go
+++ b/p2p/proxy.go
@@ -112,11 +112,8 @@ func (p *Proxy) Start() error {
 	go p.read(p.Peer2, p.Peer1, errorChannel)
 
 	if p.Peer2.handshakeInfo != nil {
-
-		err := triggerHandshake(p.Peer2)
-		if err != nil {
-			return errors.Wrap(err, "connect and start: trigger handshake")
-		}
+		return errors.Wrap(triggerHandshake(p.Peer2),
+			"connect and start: trigger handshake")
 	}
 
 	//p2pLog.Info("Started")

--- a/p2p/proxy.go
+++ b/p2p/proxy.go
@@ -1,7 +1,7 @@
 package p2p
 
 import (
-	"fmt"
+	"github.com/pkg/errors"
 
 	"go.uber.org/zap"
 
@@ -38,7 +38,7 @@ func (p *Proxy) read(sender *Peer, receiver *Peer, errChannel chan error) {
 		packet, err := sender.Read()
 		//p2pLog.Debug("Received for packet")
 		if err != nil {
-			errChannel <- fmt.Errorf("read message from %s: %s", sender.Address, err)
+			errChannel <- errors.Wrapf(err, "read message from %s", sender.Address)
 			return
 		}
 		err = p.handle(packet, sender, receiver)
@@ -52,12 +52,12 @@ func (p *Proxy) handle(packet *eos.Packet, sender *Peer, receiver *Peer) error {
 
 	_, err := receiver.Write(packet.Raw)
 	if err != nil {
-		return fmt.Errorf("handleDefault: %s", err)
+		return errors.Wrapf(err, "handleDefault")
 	}
 
 	switch m := packet.P2PMessage.(type) {
 	case *eos.GoAwayMessage:
-		return fmt.Errorf("handling message: go away: reason [%d]", m.Reason)
+		return errors.Errorf("handling message: go away: reason [%d]", m.Reason)
 	}
 
 	envelope := NewEnvelope(sender, receiver, packet)
@@ -115,7 +115,7 @@ func (p *Proxy) Start() error {
 
 		err := triggerHandshake(p.Peer2)
 		if err != nil {
-			return fmt.Errorf("connect and start: trigger handshake: %s", err)
+			return errors.Wrap(err, "connect and start: trigger handshake")
 		}
 	}
 

--- a/p2p/relay.go
+++ b/p2p/relay.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/pkg/errors"
+
 	"go.uber.org/zap"
 )
 
@@ -73,7 +75,7 @@ func (r *Relay) Start() error {
 	for {
 		ln, err := net.Listen("tcp", r.listeningAddress)
 		if err != nil {
-			return fmt.Errorf("peer init: listening %s: %s", r.listeningAddress, err)
+			return errors.Wrapf(err, "peer init: listening %s", r.listeningAddress)
 		}
 
 		p2pLog.Info("Accepting connection", zap.String("listen", r.listeningAddress))


### PR DESCRIPTION
In p2p pkg, there is a lots of err be warp by `fmt.Errorf("XXX %s", err)`, 
we can use a better way to warp by errors pkg, just like this [https://dave.cheney.net/2016/04/27/dont-just-check-errors-handle-them-gracefully](url).