### PR TITLE
better apiError string message

### DIFF
--- a/error.go
+++ b/error.go
@@ -47,10 +47,10 @@ type APIErrorDetail struct {
 
 func (e APIError) Error() string {
 	msg := e.Message
-	msg = fmt.Sprintf("%s, %s", msg, e.ErrorStruct.What)
+	msg = fmt.Sprintf("%s: %s", msg, e.ErrorStruct.What)
 
 	for _, detail := range e.ErrorStruct.Details {
-		msg = fmt.Sprintf("%s, %s", msg, detail.Message)
+		msg = fmt.Sprintf("%s: %s", msg, detail.Message)
 	}
 
 	return msg

--- a/error.go
+++ b/error.go
@@ -1,6 +1,8 @@
 package eos
 
 import (
+	"fmt"
+
 	"github.com/eoscanada/eos-go/eoserr"
 )
 
@@ -44,5 +46,12 @@ type APIErrorDetail struct {
 }
 
 func (e APIError) Error() string {
-	return e.Message
+	msg := e.Message
+	msg = fmt.Sprintf("%s, %s", msg, e.ErrorStruct.What)
+
+	for _, detail := range e.ErrorStruct.Details {
+		msg = fmt.Sprintf("%s, %s", msg, detail.Message)
+	}
+
+	return msg
 }


### PR DESCRIPTION
This is to fix issue : https://github.com/eoscanada/eos-go/issues/98

Better apiError string message

Will produce something like `Internal Service Error, Contract Table Query Exception, Table bad is not specified in the ABI`
