### PR TITLE
Added support for int compression type in JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .envrc
 .idea
+
+# Added temporarly until we actually use go.mod in this lib, so it's possible to easily hack the lib as needed
+go.mod


### PR DESCRIPTION
It appears that `eosjs` output the `compression` fied in JSON using an integer. This passes when sent to `nodeos` so it seems it's correctly supported.

Source code of `nodeos` also seems to implies that is possible to use a string for the `compression` field (from various comments on `cleos` source code). Investigation was not full in the sense that it's not clear if the underlying source supports both.

Since the eos-go implementation was supporting string version, I decided to simply added support for `uint8` support if string fails with an unmarshal type error.