### PR TITLE
Fixes a few problem with ABI decoding

### DIFF
--- a/abi.go
+++ b/abi.go
@@ -57,13 +57,13 @@ func (a *ABI) TableForName(name TableName) *TableDef {
 	return nil
 }
 
-func (a *ABI) TypeNameForNewTypeName(typeName string) string {
+func (a *ABI) TypeNameForNewTypeName(typeName string) (resolvedTypeName string, isAlias bool) {
 	for _, t := range a.Types {
 		if t.NewTypeName == typeName {
-			return t.Type
+			return t.Type, true
 		}
 	}
-	return typeName
+	return typeName, false
 }
 
 type ABIType struct {

--- a/abiencoder.go
+++ b/abiencoder.go
@@ -70,9 +70,9 @@ func (a *ABI) encodeFields(binaryEncoder *Encoder, fields []FieldDef, json []byt
 		abiEncoderLog.Debug("encode field", zap.String("name", field.Name), zap.String("type", field.Type))
 
 		fieldType, isOptional, isArray := analyzeFieldType(field.Type)
-		typeName := a.TypeNameForNewTypeName(fieldType)
+		typeName, isAlias := a.TypeNameForNewTypeName(fieldType)
 		fieldName := field.Name
-		if typeName != field.Type {
+		if isAlias {
 			abiEncoderLog.Debug("type is an alias", zap.String("from", field.Type), zap.String("to", typeName))
 		}
 

--- a/abiencoder_test.go
+++ b/abiencoder_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 )
 
@@ -92,7 +93,8 @@ func TestABIEncoder_Encode(t *testing.T) {
 		t.Run(caseName, func(t *testing.T) {
 
 			abi, err := NewABI(strings.NewReader(c["abi"].(string)))
-			assert.NoError(t, err)
+			require.NoError(t, err)
+
 			_, err = abi.EncodeAction(ActionName(c["actionName"].(string)), abiData)
 			assert.Equal(t, c["expectedError"], err)
 
@@ -103,7 +105,7 @@ func TestABIEncoder_Encode(t *testing.T) {
 			//decoder := NewABIDecoder(buf.Bytes(), strings.NewReader(abiString))
 			//result := make(M)
 			//err = decoder.Decode(result, ActionName(c["actionName"].(string)))
-			//assert.NoError(t, err)
+			//require.NoError(t, err)
 
 			//assert.Equal(t, abiData, result)
 			//fmt.Println(result)
@@ -129,8 +131,10 @@ func TestABIEncoder_encodeMissingActionStruct(t *testing.T) {
   }]
 }
 `
+
 	abi, err := NewABI(strings.NewReader(abiString))
-	assert.NoError(t, err)
+	require.NoError(t, err)
+
 	_, err = abi.EncodeAction(ActionName("action.name.1"), abiData)
 	assert.Equal(t, fmt.Errorf("encode action: encode struct [struct.name.1] not found in abi"), err)
 }
@@ -160,8 +164,10 @@ func TestABIEncoder_encodeErrorInBase(t *testing.T) {
   }]
 }
 `
+
 	abi, err := NewABI(strings.NewReader(abiString))
-	assert.NoError(t, err)
+	require.NoError(t, err)
+
 	_, err = abi.EncodeAction(ActionName("action.name.1"), abiData)
 	assert.Equal(t, fmt.Errorf("encode action: encode base [struct.name.1]: encode struct [struct.name.2] not found in abi"), err)
 }
@@ -310,10 +316,8 @@ func TestABI_Write(t *testing.T) {
 			fieldName := "test_field_name"
 			result := gjson.Get(c["json"].(string), "testField")
 			err := abi.writeField(encoder, fieldName, c["typeName"].(string), result)
-			if err != nil {
-				fmt.Println(err.Error())
-			}
-			assert.Equal(t, c["expectedError"], err, c["caseName"])
+
+			require.Equal(t, c["expectedError"], err, c["caseName"])
 
 			if c["expectedError"] == nil {
 				assert.Equal(t, c["expectedValue"], hex.EncodeToString(buffer.Bytes()), c["caseName"])

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -9,10 +9,9 @@ import (
 
 	"time"
 
-	"fmt"
-
 	"github.com/eoscanada/eos-go/ecc"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDecoder_Remaining(t *testing.T) {
@@ -296,8 +295,8 @@ func TestDecoder_PublicKey_R1(t *testing.T) {
 	d := NewDecoder(buf.Bytes())
 
 	rpk, err := d.ReadPublicKey()
-	fmt.Printf("Key %s\n", rpk.String())
-	assert.NoError(t, err)
+
+	require.NoError(t, err)
 
 	assert.Equal(t, pk, rpk)
 	assert.Equal(t, 0, d.remaining())
@@ -371,16 +370,6 @@ func TestDecoder_BlockTimestamp(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, ts, rbt)
 	assert.Equal(t, 0, d.remaining())
-}
-
-func TestDecoder_Time(t *testing.T) {
-	time := time.Now()
-
-	buf := new(bytes.Buffer)
-	enc := NewEncoder(buf)
-	enc.Encode(&time)
-
-	fmt.Println(buf.Bytes())
 }
 
 type EncodeTestStruct struct {

--- a/init_test.go
+++ b/init_test.go
@@ -1,0 +1,16 @@
+package eos
+
+import (
+	"os"
+
+	"go.uber.org/zap"
+)
+
+func init() {
+	if os.Getenv("DEBUG") != "" {
+		encoderLog, _ = zap.NewDevelopment()
+		decoderLog, _ = zap.NewDevelopment()
+		abiEncoderLog, _ = zap.NewDevelopment()
+		abiDecoderLog, _ = zap.NewDevelopment()
+	}
+}


### PR DESCRIPTION
- A struct field with a base type was not handled correctly.
- A struct field base type was not resolved against aliases.
- Put the correct logger everywhere in decoder.