### PR TITLE
get_table_by_scope improvements

### DIFF
--- a/responses.go
+++ b/responses.go
@@ -192,7 +192,7 @@ type GetTableByScopeRequest struct {
 }
 
 type GetTableByScopeResp struct {
-	More bool            `json:"more"`
+	More string          `json:"more"`
 	Rows json.RawMessage `json:"rows"`
 }
 

--- a/responses.go
+++ b/responses.go
@@ -192,8 +192,17 @@ type GetTableByScopeRequest struct {
 }
 
 type GetTableByScopeResp struct {
-	More string          `json:"more"`
-	Rows json.RawMessage `json:"rows"`
+	More string                     `json:"more"`
+	Rows []GetTableByScopeResultRow `json:"rows"`
+}
+
+// GetTableByScopeResultRow is a row of data returned by chain/get_table_by_scope API endpoint
+type GetTableByScopeResultRow struct {
+	Code  string `json:"code"`
+	Scope string `json:"scope"`
+	Table string `json:"table"`
+	Payer string `json:"payer"`
+	Count int    `json:"count"`
 }
 
 type GetTableRowsRequest struct {


### PR DESCRIPTION
Here are a few improvements:

1. 'more' field in response is of type 'string', not 'boolean' (https://github.com/EOSIO/eos/blob/686f0deb5dac097cc292f735ccb47c238e763de0/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp#L303)

2. It always returns a JSON with a predefined structure, but there's no handy method to unmarshal it (like `JSONToStructs` in `GetTableRowsRequest`). And actually there's no need to unmarshal it manually, because it always responses with the same JSON structure. So let's unmarshal it automatically.