### PR TITLE
Fields of Authority shouldn't be omitted

### DIFF
--- a/system/newaccount_test.go
+++ b/system/newaccount_test.go
@@ -37,6 +37,8 @@ func TestActionNewAccount(t *testing.T) {
 						Weight:    1,
 					},
 				},
+				Accounts: []eos.PermissionLevelWeight{},
+				Waits:    []eos.WaitWeight{},
 			},
 			Active: eos.Authority{
 				Threshold: 1,
@@ -46,6 +48,8 @@ func TestActionNewAccount(t *testing.T) {
 						Weight:    1,
 					},
 				},
+				Accounts: []eos.PermissionLevelWeight{},
+				Waits:    []eos.WaitWeight{},
 			},
 		}),
 	}
@@ -66,7 +70,7 @@ func TestActionNewAccount(t *testing.T) {
 	buf, err = json.Marshal(a.ActionData.Data)
 	assert.NoError(t, err)
 
-	assert.Equal(t, "{\"creator\":\"eosio\",\"name\":\"abourget\",\"owner\":{\"threshold\":1,\"keys\":[{\"key\":\"EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV\",\"weight\":1}]},\"active\":{\"threshold\":1,\"keys\":[{\"key\":\"EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV\",\"weight\":1}]}}", string(buf))
+	assert.Equal(t, "{\"creator\":\"eosio\",\"name\":\"abourget\",\"owner\":{\"threshold\":1,\"keys\":[{\"key\":\"EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV\",\"weight\":1}],\"accounts\":[],\"waits\":[]},\"active\":{\"threshold\":1,\"keys\":[{\"key\":\"EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV\",\"weight\":1}],\"accounts\":[],\"waits\":[]}}", string(buf))
 	// 00096e88 0000 0000 00000000 00 00 00 00 01 0000000000ea3055
 
 	// WUTz that ?

--- a/types.go
+++ b/types.go
@@ -487,9 +487,9 @@ type PermissionLevelWeight struct {
 
 type Authority struct {
 	Threshold uint32                  `json:"threshold"`
-	Keys      []KeyWeight             `json:"keys,omitempty"`
-	Accounts  []PermissionLevelWeight `json:"accounts,omitempty"`
-	Waits     []WaitWeight            `json:"waits,omitempty"`
+	Keys      []KeyWeight             `json:"keys"`
+	Accounts  []PermissionLevelWeight `json:"accounts"`
+	Waits     []WaitWeight            `json:"waits"`
 }
 
 type KeyWeight struct {


### PR DESCRIPTION
For example, when calling `updateauth` action and passing an authority without `waits` field set, you'll get an error, because the JSON won't contain `waits` field at all, and the action requires all of them.