### PR TITLE
Fix go away reason diff between eosio

### DIFF
--- a/p2ptypes.go
+++ b/p2ptypes.go
@@ -66,10 +66,10 @@ const (
 	GoAwayUnlinkable
 	GoAwayBadTransaction
 	GoAwayValidation
-	GoAwayAuthentication
-	GoAwayFatalOther
 	GoAwayBenignOther
-	GoAwayCrazy
+	GoAwayFatalOther
+	GoAwayAuthentication
+	GoAwayCrazy // not in eosio code
 )
 
 func (r GoAwayReason) String() string {


### PR DESCRIPTION
In eosio the go away reason define is:

```cpp
  enum go_away_reason {
    no_reason, ///< no reason to go away
    ...
    validation, ///< the peer sent a block that failed validation
    benign_other, ///< reasons such as a timeout. not fatal but warrant resetting
    fatal_other, ///< a catch-all for errors we don't have discriminated
    authentication ///< peer failed authenicatio
  };
```

the define in eos-go is diff between eosio, and it will case some trouble for the user.