### PR TITLE
GetTableByScopeResp.more is string now.

### DIFF
--- a/responses.go
+++ b/responses.go
@@ -220,7 +220,7 @@ type GetTableByScopeRequest struct {
 }
 
 type GetTableByScopeResp struct {
-	More bool            `json:"more"`
+	More string          `json:"more"`
 	Rows json.RawMessage `json:"rows"`
 }
 


### PR DESCRIPTION
When I use this struct ，It get an error:
panic: get info: Unmarshal: json: cannot unmarshal string into Go struct field GetTableByScopeResp.more of type bool
So, the more should be string now , maybe other struct also need to change.