### PR TITLE
fix json tags for delegatebw action data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * BREAKING: The serialization for `ExtendedAsset` was aligned with the `eos` codebase.  Beforehand, it would serialize the field name `"Contract"` with a capital `C`, and the `Asset` field as `"asset"` where it should have been `"quantity"`.
+
+### Fixed
+
+* Fix json tags for delegatebw action data.

--- a/system/delegatebw.go
+++ b/system/delegatebw.go
@@ -27,7 +27,7 @@ func NewDelegateBW(from, receiver eos.AccountName, stakeCPU, stakeNet eos.Asset,
 type DelegateBW struct {
 	From     eos.AccountName `json:"from"`
 	Receiver eos.AccountName `json:"receiver"`
-	StakeNet eos.Asset       `json:"stake_net"`
-	StakeCPU eos.Asset       `json:"stake_cpu"`
+	StakeNet eos.Asset       `json:"stake_net_quantity"`
+	StakeCPU eos.Asset       `json:"stake_cpu_quantity"`
 	Transfer eos.Bool        `json:"transfer"`
 }


### PR DESCRIPTION
delegatebw actions fail to deserialize as net and cpu stake assets are named `stake_net_quantity` and `stake_cpu_quantity` instead of `stake_net` and `stake_cpu`, see [here](https://github.com/EOSIO/eosio.contracts/blob/master/contracts/eosio.system/src/delegate_bandwidth.cpp#L375-L377)