### PR TITLE
add setter for updating public key compatible prefix

### DIFF
--- a/ecc/pubkey.go
+++ b/ecc/pubkey.go
@@ -101,6 +101,8 @@ func NewPublicKey(pubKey string) (out PublicKey, err error) {
 		return out, fmt.Errorf("invalid format")
 	}
 
+	pubKeyReaderManifestsMux.Lock()
+	defer pubKeyReaderManifestsMux.Unlock()
 	for prefix, manifest := range pubKeyReaderManifests {
 		if !strings.HasPrefix(pubKey, prefix) {
 			continue

--- a/ecc/pubkey.go
+++ b/ecc/pubkey.go
@@ -16,6 +16,9 @@ var PublicKeyPrefix = "PUB_"
 var PublicKeyK1Prefix = "PUB_K1_"
 var PublicKeyR1Prefix = "PUB_R1_"
 var PublicKeyWAPrefix = "PUB_WA_"
+
+// PublicKeyPrefixCompat holds the current compatible key prefix, for chains other than EOS it can be overridden by
+// calling ecc.SetPublicKeyPrefixCompat
 var PublicKeyPrefixCompat = "EOS"
 
 var publicKeyDataSize = new(int)

--- a/ecc/pubkey.go
+++ b/ecc/pubkey.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/eoscanada/eos-go/btcsuite/btcd/btcec"
 	"github.com/eoscanada/eos-go/btcsuite/btcutil/base58"
@@ -80,6 +81,16 @@ var pubKeyReaderManifests = map[string]pubkeyReaderManifest{
 	PublicKeyK1Prefix:     {CurveK1, newInnerK1PublicKey},
 	PublicKeyR1Prefix:     {CurveR1, newInnerR1PublicKey},
 	PublicKeyWAPrefix:     {CurveWA, newInnerWAPublicKey},
+}
+var pubKeyReaderManifestsMux sync.Mutex
+
+func SetPublicKeyPrefixCompat(prefix string) {
+	pubKeyReaderManifestsMux.Lock()
+	if pubKeyReaderManifests[prefix].inner == nil {
+		pubKeyReaderManifests[prefix] = pubkeyReaderManifest{CurveK1, newInnerK1PublicKey}
+	}
+	pubKeyReaderManifestsMux.Unlock()
+	PublicKeyPrefixCompat = prefix
 }
 
 func NewPublicKey(pubKey string) (out PublicKey, err error) {

--- a/ecc/pubkey_test.go
+++ b/ecc/pubkey_test.go
@@ -45,6 +45,35 @@ func Test_PublicKeyMarshalUnmarshal(t *testing.T) {
 	}
 }
 
+func Test_PublicKeyMarshalUnmarshalAltPrefix(t *testing.T) {
+	SetPublicKeyPrefixCompat("ABC")
+	defer SetPublicKeyPrefixCompat("EOS")
+	cases := []struct {
+		name        string
+		key         string
+		expectedKey string
+	}{
+		{
+			name:        "K1-ABC",
+			key:         PublicKeyPrefixCompat + "6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV",
+			expectedKey: PublicKeyPrefixCompat + "6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV",
+		},
+		{
+			name:        "K1",
+			key:         "PUB_K1_6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV",
+			expectedKey: PublicKeyPrefixCompat + "6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			key, err := NewPublicKey(c.key)
+			require.NoError(t, err)
+			assert.Equal(t, c.expectedKey, key.String())
+		})
+	}
+}
+
 func TestPublicKey_MarshalJSON(t *testing.T) {
 	cases := []struct {
 		name         string
@@ -70,6 +99,39 @@ func TestPublicKey_MarshalJSON(t *testing.T) {
 			name:         "WA",
 			key:          "PUB_WA_5hyixc7vkMbKiThWi1TnFtXw7HTDcHfjREj2SzxCtgw3jQGepa5T9VHEy1Tunjzzj",
 			expectedJSON: `"PUB_WA_5hyixc7vkMbKiThWi1TnFtXw7HTDcHfjREj2SzxCtgw3jQGepa5T9VHEy1Tunjzzj"`,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			key, err := NewPublicKey(c.key)
+			require.NoError(t, err)
+
+			result, err := key.MarshalJSON()
+			require.NoError(t, err)
+
+			assert.Equal(t, []byte(c.expectedJSON), result)
+		})
+	}
+}
+
+func TestPublicKey_MarshalJSONAltPrefix(t *testing.T) {
+	SetPublicKeyPrefixCompat("ABC")
+	defer SetPublicKeyPrefixCompat("EOS")
+	cases := []struct {
+		name         string
+		key          string
+		expectedJSON string
+	}{
+		{
+			name:         "K1-ABC",
+			key:          PublicKeyPrefixCompat + "6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV",
+			expectedJSON: `"` + PublicKeyPrefixCompat + `6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV"`,
+		},
+		{
+			name:         "K1",
+			key:          "PUB_K1_6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV",
+			expectedJSON: `"` + PublicKeyPrefixCompat + `6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV"`,
 		},
 	}
 


### PR DESCRIPTION
Fixes an issue where the pubKeyReaderManifests map is never updated by adding a setter function.