### PR TITLE
Bugfix StringToSymbol

### DIFF
--- a/types.go
+++ b/types.go
@@ -17,7 +17,7 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-var symbolRegex = regexp.MustCompile("^[0-9],[A-Z]{1,7}$")
+var symbolRegex = regexp.MustCompile("^[0-9]{1,2},[A-Z]{1,7}$")
 var symbolCodeRegex = regexp.MustCompile("^[A-Z]{1,7}$")
 
 // For reference:
@@ -260,11 +260,11 @@ func StringToSymbol(str string) (Symbol, error) {
 	if !symbolRegex.MatchString(str) {
 		return symbol, fmt.Errorf("%s is not a valid symbol", str)
 	}
-
-	precision, _ := strconv.ParseUint(string(str[0]), 10, 8)
+	arrs := strings.Split(str, ",")
+	precision, _ := strconv.ParseUint(string(arrs[0]), 10, 8)
 
 	symbol.Precision = uint8(precision)
-	symbol.Symbol = str[2:]
+	symbol.Symbol = arrs[1]
 
 	return symbol, nil
 }

--- a/types_test.go
+++ b/types_test.go
@@ -527,11 +527,9 @@ func TestStringToSymbol(t *testing.T) {
 		{"4,IQ", Symbol{Precision: 4, Symbol: "IQ"}, "........e54k4", nil},
 		{"4,EOS", Symbol{Precision: 4, Symbol: "EOS"}, "......2ndx2k4", nil},
 		{"9,EOSEOSA", Symbol{Precision: 9, Symbol: "EOSEOSA"}, "c5doylendx2kd", nil},
-
+		{"10,EOS", Symbol{Precision: 10, Symbol: "EOS"}, "......2ndx2ke", nil},
 		{"EOS", Symbol{}, "", errors.New("EOS is not a valid symbol")},
 		{",EOS", Symbol{}, "", errors.New(",EOS is not a valid symbol")},
-		{"10,EOS", Symbol{}, "", errors.New("10,EOS is not a valid symbol")},
-		{"10,EOS", Symbol{}, "", errors.New("10,EOS is not a valid symbol")},
 		{"1,EOSEOSEO", Symbol{}, "", errors.New("1,EOSEOSEO is not a valid symbol")},
 	}
 


### PR DESCRIPTION
Actually, the precision of token symbol on EOS can be >= 10, examples:
[gemtokencode](https://bloks.io/account/gemtokencode?loadContract=true&tab=Tables&table=stat&account=gemtokencode&scope=GEM&limit=100)
[eosdmdtokens](https://bloks.io/account/eosdmdtokens?loadContract=true&tab=Tables&table=stat&account=eosdmdtokens&scope=DMD&limit=100)
