### PR TITLE
fix serialization of TimePointSec

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -170,7 +170,7 @@ func (e *Encoder) Encode(v interface{}) (err error) {
 	case TimePoint:
 		return e.writeUint64(uint64(cv))
 	case TimePointSec:
-		return e.writeUint64(uint64(cv))
+		return e.writeUint32(uint32(cv))
 	case nil:
 	default:
 


### PR DESCRIPTION
This is a fix for https://github.com/eoscanada/eos-go/issues/153