### PR TITLE
SignedBlockBytes's UnmarshalBinary() does a recursive call

### DIFF
--- a/ship/types.go
+++ b/ship/types.go
@@ -158,7 +158,7 @@ func (s *SignedBlockBytes) UnmarshalBinary(decoder *eos.Decoder) error {
 	if err != nil {
 		return err
 	}
-	return eos.UnmarshalBinary(data, s)
+	return eos.UnmarshalBinary(data, (*SignedBlock)(s))
 }
 
 type Extension struct {


### PR DESCRIPTION
`UnmarshalBinary()` for `SignedBlockBytes` type makes a recursive call (`eos.UnmarshalBinary(data, s)`) 

This results in multiple `SignedBlockBytes` are being parsed until it fails when `decoder.ReadByteArray()` overflows.


See this debug log:
```
2022-01-12T17:28:19.312+0100	DEBUG	eos-go@v0.10.0/decoder.go:562	struct field	{"Block": "**eos.SignedBlockBytes", "tag": "optional"}
2022-01-12T17:28:19.312+0100	DEBUG	eos-go@v0.10.0/decoder.go:165	decode type	{"type": "**eos.SignedBlockBytes", "optional": true}
2022-01-12T17:28:19.312+0100	DEBUG	eos-go@v0.10.0/decoder.go:650	read byte	{"byte": 1}
2022-01-12T17:28:19.312+0100	DEBUG	eos-go@v0.10.0/decoder.go:200	using UnmarshalBinary method to decode type	{"type": "**eos.SignedBlockBytes"}
2022-01-12T17:28:19.312+0100	DEBUG	eos-go@v0.10.0/decoder.go:581	read uvarint64	{"val": 19472}
2022-01-12T17:28:19.312+0100	DEBUG	eos-go@v0.10.0/decoder.go:636	read byte array	{"hex": .... }
2022-01-12T17:28:19.313+0100	DEBUG	eos-go@v0.10.0/decoder.go:165	decode type	{"type": "*eos.SignedBlockBytes", "optional": false}
2022-01-12T17:28:19.314+0100	DEBUG	eos-go@v0.10.0/decoder.go:216	using UnmarshalBinary method to decode type	{"type": "*eos.SignedBlockBytes"}
2022-01-12T17:28:19.314+0100	DEBUG	eos-go@v0.10.0/decoder.go:581	read uvarint64	{"val": 70}
2022-01-12T17:28:19.314+0100	DEBUG	eos-go@v0.10.0/decoder.go:636	read byte array	{"hex": "7ce35280b1915e5d268dca0000099a2eb0bce874472584b9e2faaceb8f51087380bfdc101a3a9562bc115160df3a40b763f883961c42b41d6692c66757afd1ab1c0a25375cd8"}
2022-01-12T17:28:19.314+0100	DEBUG	eos-go@v0.10.0/decoder.go:165	decode type	{"type": "*eos.SignedBlockBytes", "optional": false}
2022-01-12T17:28:19.314+0100	DEBUG	eos-go@v0.10.0/decoder.go:216	using UnmarshalBinary method to decode type	{"type": "*eos.SignedBlockBytes"}
2022-01-12T17:28:19.314+0100	DEBUG	eos-go@v0.10.0/decoder.go:581	read uvarint64	{"val": 124}
2022/01/12 17:28:19 unable to decode variant type 1: byte array: varlen=124, missing 55 bytes
```

This PR fixes the issue by casting `s` to `*SignedBlock`.