### PR TITLE
Fix NewPrivateKey correctly working with PVT_K1 keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Fixed
 
+Fix NewPrivateKey correctly working with PVT_K1 keys (#177)
+
 #### Deprecated
 
 ### [**0.10.2**](https://github.com/eoscanada/eos-go/releases/tag/v0.10.2) (January 19th, 2022)

--- a/ecc/crypto_test.go
+++ b/ecc/crypto_test.go
@@ -21,14 +21,14 @@ func TestK1PrivateToPublic(t *testing.T) {
 }
 
 func TestPrefixedK1PrivateToPublic(t *testing.T) {
-	wif := "PVT_K1_5KYZdUEo39z3FPrtuX2QbbwGnNP5zTd7yyr2SC1j299sBCnWjss"
+	wif := "PVT_K1_9FN3K4JhzaMsw2Duzr1ijHzVecHtqg1QG4ZCX9udh69Z7QGTk"
 	privKey, err := NewPrivateKey(wif)
 	require.NoError(t, err)
 
 	pubKey := privKey.PublicKey()
 
 	pubKeyString := pubKey.String()
-	assert.Equal(t, PublicKeyPrefixCompat+"859gxfnXyUriMgUeThh1fWv3oqcpLFyHa3TfFYC4PK2HqhToVM", pubKeyString)
+	assert.Equal(t, PublicKeyPrefixCompat+"7LrH8N3f3BTCLRHQWeo9gVfuBB6XgEqtjksKoN9jhjFjbaGQES", pubKeyString)
 }
 
 func TestR1PrivateToPublic(t *testing.T) {
@@ -39,8 +39,8 @@ func TestR1PrivateToPublic(t *testing.T) {
 	// FIXME: Actual retrieval of publicKey from privateKey for R1 is not done yet, disable this check
 	// pubKey := privKey.PublicKey()
 
-	//pubKeyString := pubKey.String()
-	//assert.Equal(t, "PUB_R1_0000000000000000000000000000000000000000000000", pubKeyString)
+	// pubKeyString := pubKey.String()
+	// assert.Equal(t, "PUB_R1_0000000000000000000000000000000000000000000000", pubKeyString)
 }
 
 func TestNewPublicKeyAndSerializeCompress(t *testing.T) {

--- a/ecc/privkey.go
+++ b/ecc/privkey.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/eoscanada/eos-go/btcsuite/btcd/btcec"
 	"github.com/eoscanada/eos-go/btcsuite/btcutil"
+	"github.com/eoscanada/eos-go/btcsuite/btcutil/base58"
 )
 
 const PrivateKeyPrefix = "PVT_"
@@ -50,8 +51,13 @@ func NewPrivateKey(wif string) (*PrivateKey, error) {
 
 		switch curvePrefix {
 		case "K1_":
+			// See https://github.com/EOSIO/eosjs-ecc/blob/a806b93fbbccec8d38c0c02998d204ff2040a6ae/src/key_private.js#L50
+			decoded := base58.Decode(privKeyMaterial)
+			key := append([]byte{128}, decoded[:len(decoded)-4]...)
+			checksum := btcutil.DoubleHashB(key)
+			wifKey := base58.Encode(append(key, checksum[0:4]...))
 
-			wifObj, err := btcutil.DecodeWIF(privKeyMaterial)
+			wifObj, err := btcutil.DecodeWIF(wifKey)
 			if err != nil {
 				return nil, err
 			}

--- a/ecc/privkey_test.go
+++ b/ecc/privkey_test.go
@@ -1,0 +1,30 @@
+package ecc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_NewPrivateKey(t *testing.T) {
+	cases := []struct {
+		name        string
+		key         string
+		expectedKey string
+	}{
+		{
+			name:        "K1",
+			key:         "PVT_K1_9FN3K4JhzaMsw2Duzr1ijHzVecHtqg1QG4ZCX9udh69Z7QGTk",
+			expectedKey: "5HxXwim9PAZZctKJG7Sk6mURD6UXW2hkjDKqnNZu9WYjKD6fF5a",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			key, err := NewPrivateKey(c.key)
+			require.NoError(t, err)
+			assert.Equal(t, c.expectedKey, key.String())
+		})
+	}
+}


### PR DESCRIPTION
Fix NewPrivateKey correctly working with PVT_K1 keys. Added test for PVT_K1 NewPrivateKey.