### PR TITLE
add action_trace_v1 to ship types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Unreleased
 
+* Added `action_trace_v1` field
+
 #### Breaking Changes
 
 #### Added

--- a/ship/types.go
+++ b/ship/types.go
@@ -65,9 +65,24 @@ type ActionTraceV0 struct {
 	ContextFree          bool
 	Elapsed              int64
 	Console              eos.SafeString
-	AccountRamDeltas     []*eos.AccountRAMDelta
+	AccountRamDeltas     []*eos.AccountDelta
 	Except               string `eos:"optional"`
 	ErrorCode            uint64 `eos:"optional"`
+}
+
+type ActionTraceV1 struct {
+	ActionOrdinal        eos.Varuint32
+	CreatorActionOrdinal eos.Varuint32
+	Receipt              *ActionReceipt `eos:"optional"`
+	Receiver             eos.Name
+	Act                  *Action
+	ContextFree          bool
+	Elapsed              int64
+	Console              eos.SafeString
+	AccountRamDeltas     []*eos.AccountDelta
+	Except               string `eos:"optional"`
+	ErrorCode            uint64 `eos:"optional"`
+	ReturnValue          []byte
 }
 
 type Action struct {

--- a/ship/variant_helpers.go
+++ b/ship/variant_helpers.go
@@ -77,6 +77,7 @@ func (r *TransactionTrace) UnmarshalBinary(decoder *eos.Decoder) error {
 // ActionTrace
 var ActionTraceVariant = eos.NewVariantDefinition([]eos.VariantType{
 	{"action_trace_v0", (*ActionTraceV0)(nil)},
+	{"action_trace_v1", (*ActionTraceV1)(nil)},
 })
 
 type ActionTrace struct {


### PR DESCRIPTION
Has been backported to Mandel, see: https://github.com/eosnetworkfoundation/mandel/commit/7da37b6bc41a63a9eaef5e79ff7aaf2aea854826