### PR TITLE
Add AsTime() helpers to TimePoint and TimePointSec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Unreleased
 
 * Added `action_trace_v1` field
+* Added `AsTime` helper functions to convert `TimePoint` and `TimePointSec` to `time.Time`
 
 #### Breaking Changes
 

--- a/types.go
+++ b/types.go
@@ -921,6 +921,12 @@ func (f *TimePoint) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// AsTime returns the TimePoint as time.Time in UTC
+func (f TimePoint) AsTime() time.Time {
+	// copied from time.UnixMicro, the latter was added in 1.17
+	return time.Unix(int64(f)/1e6, (int64(f)%1e6)*1e3).UTC()
+}
+
 // TimePointSec represents the number of seconds since EPOCH (Jan 1st 1970)
 type TimePointSec uint32
 
@@ -945,6 +951,11 @@ func (f *TimePointSec) UnmarshalJSON(data []byte) error {
 
 	*f = TimePointSec(out.Unix())
 	return nil
+}
+
+// AsTime returns the TimePointSec as time.Time in UTC
+func (f TimePointSec) AsTime() time.Time {
+	return time.Unix(int64(f), 0).UTC()
 }
 
 type JSONFloat64 = Float64

--- a/types_test.go
+++ b/types_test.go
@@ -921,3 +921,61 @@ func TestBlob(t *testing.T) {
 		assert.Empty(tt, data)
 	})
 }
+
+func TestTimePoint_AsTime(t *testing.T) {
+	tests := []struct {
+		name string
+		f    string
+		tp   TimePoint
+		want time.Time
+	}{
+		{
+			name: "converts timestamp to the correct time",
+			f:    "\"2022-06-30T09:46:14.500\"",
+			want: time.Date(2022, time.June, 30, 9, 46, 14, 500000000, time.UTC),
+		},
+		{
+			name: "converts zero value to correct time",
+			want: time.Unix(0, 0).UTC(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if len(tt.f) > 0 {
+				err := tt.tp.UnmarshalJSON([]byte(tt.f))
+				require.NoError(t, err)
+			}
+
+			assert.Equalf(t, tt.want, tt.tp.AsTime(), "AsTime()")
+		})
+	}
+}
+
+func TestTimePointSec_AsTime(t *testing.T) {
+	tests := []struct {
+		name string
+		f    string
+		tp   TimePointSec
+		want time.Time
+	}{
+		{
+			name: "converts timestamp to the correct time",
+			f:    "\"2022-07-01T06:40:10\"",
+			want: time.Date(2022, time.July, 1, 6, 40, 10, 0, time.UTC),
+		},
+		{
+			name: "converts zero value to correct time",
+			want: time.Unix(0, 0).UTC(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if len(tt.f) > 0 {
+				err := tt.tp.UnmarshalJSON([]byte(tt.f))
+				require.NoError(t, err)
+			}
+
+			assert.Equalf(t, tt.want, tt.tp.AsTime(), "AsTime()")
+		})
+	}
+}


### PR DESCRIPTION
doing this every time you need to compare timestamps using `time.Time{}.After` or similar methods makes it error prone, since both `TimePoint` and `TimePointSec` have the same underlying type.