### PR TITLE
Encoding ship types

### DIFF
--- a/ship/variant_helpers.go
+++ b/ship/variant_helpers.go
@@ -126,6 +126,14 @@ type TableDeltaArray struct {
 	Elem []*TableDelta
 }
 
+func (d TableDeltaArray) MarshalBinary(enc *eos.Encoder) error {
+	data, err := eos.MarshalBinary(d.Elem)
+	if err != nil {
+		return err
+	}
+	return enc.Encode(data)
+}
+
 func (d *TableDeltaArray) UnmarshalBinary(decoder *eos.Decoder) error {
 	data, err := decoder.ReadByteArray()
 	if err != nil {

--- a/ship/variant_helpers.go
+++ b/ship/variant_helpers.go
@@ -62,6 +62,14 @@ func (t *TransactionTraceArray) AsTransactionTracesV0() (out []*TransactionTrace
 	return out
 }
 
+func (r TransactionTraceArray) MarshalBinary(enc *eos.Encoder) error {
+	data, err := eos.MarshalBinary(r.Elem)
+	if err != nil {
+		return err
+	}
+	return enc.Encode(data)
+}
+
 func (r *TransactionTraceArray) UnmarshalBinary(decoder *eos.Decoder) error {
 	data, err := decoder.ReadByteArray()
 	if err != nil {


### PR DESCRIPTION
Adding MarshalBinary() functions for Arrays (TransactionTraceArray and TableDeltaArray)

Without these functions those datatypes are not encoded as byte arrays when passed to eos.MarshalBinary()