### PR TITLE
fix decoding of table rows with variant types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Fixed
 
+* Fixed decoding of table rows with variant types.
+
 * Fixed serialization of `map[K]V` when using `eos.MarshalBinary` so that ordering in which the keys are serialized is in lexicographical order, just like JSON serialization.
 
 * Updated to latest version of `github.com/streamingfast/logging` library.

--- a/abidecoder.go
+++ b/abidecoder.go
@@ -80,6 +80,14 @@ func (a *ABI) decode(binaryDecoder *Decoder, structName string) (map[string]inte
 		zlog.Debug("decode struct", zap.String("name", structName))
 	}
 
+	if variant := a.VariantForName(structName); variant != nil {
+		out, err := binaryDecoder.ReadUvarint32()
+		if err != nil {
+			zlog.Error("error reading variant", zap.Error(err))
+		}
+		structName = variant.Types[out]
+	}
+
 	structure := a.StructForName(structName)
 	if structure == nil {
 		return nil, fmt.Errorf("structure [%s] not found in abi", structName)

--- a/abidecoder_test.go
+++ b/abidecoder_test.go
@@ -150,6 +150,64 @@ func TestABI_DecodeTable(t *testing.T) {
 
 }
 
+func Test_ExampleABI_DecodeTableRowVariant(t *testing.T) {
+
+	abiString := `
+{
+  "version": "eosio::abi/1.3",
+  "types": [],
+  "structs": [
+    {
+      "name": "account_v0",
+      "base": "",
+      "fields": [
+        {
+          "name": "owner",
+          "type": "name"
+        },
+        {
+          "name": "balance",
+          "type": "asset"
+        }
+      ]
+    }
+  ],
+  "actions": [],
+  "tables": [
+    {
+      "name": "account",
+      "index_type": "i64",
+      "type": "variant<account_v0>"
+    }
+  ],
+  "ricardian_clauses": [],
+  "variants": [
+    {
+      "name": "variant<account_v0>",
+      "types": [
+        "account_v0"
+      ]
+    }
+  ]
+}
+`
+
+	abi, err := NewABI(strings.NewReader(abiString))
+	require.NoError(t, err)
+
+	tableDef := abi.TableForName("account")
+	require.NotNil(t, tableDef)
+
+	data, err := hex.DecodeString(`00000000005c95b191198a8abe0000000004454f5300000000`)
+	require.NoError(t, err)
+
+	res, err := abi.DecodeTableRowTyped(tableDef.Type, data)
+	require.NoError(t, err)
+
+	assert.Equal(t, "master", gjson.GetBytes(res, "owner").String())
+	assert.Equal(t, "319675.0361 EOS", gjson.GetBytes(res, "balance").String())
+}
+
 func TestABI_DecodeTableRowMissingTable(t *testing.T) {
 
 	abiReader := strings.NewReader(abiString)

--- a/abidecoder_test.go
+++ b/abidecoder_test.go
@@ -150,7 +150,7 @@ func TestABI_DecodeTable(t *testing.T) {
 
 }
 
-func Test_ExampleABI_DecodeTableRowVariant(t *testing.T) {
+func Test_DecodeTableRowVariant(t *testing.T) {
 
 	abiString := `
 {


### PR DESCRIPTION
<!-- Optional  -->
## Background

Decoding of table rows fails if the table type is a variant. Example error from [dfuse](https://eos.dfuse.eosnation.io/v0/state/table?account=genesis.eden&scope=owned&table=account&json=true):

`row struct "variant<account_v0>", err: structure [variant<account_v0>] not found in abi`

## Summary

fixed this by having `decode()` check first if the given struct name is a variant and if so use the variant type instead.

## Note
<!--- Add More if you need. -->

## Checklist

- [x] Backward compatible?
- [ ] Test enough in your local environment?
- [x] Add related test cases?
