### PR TITLE
allow parsing of empty assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Unreleased
 
+* Changed `NewAssetFromString` validation to allow parsing of empty assets
 * Added `action_trace_v1` field
 * Added `AsTime` helper functions to convert `TimePoint` and `TimePointSec` to `time.Time`
 * Added support for decoding action results

--- a/types.go
+++ b/types.go
@@ -532,11 +532,6 @@ func NewFixedSymbolAssetFromString(symbol Symbol, input string) (out Asset, err 
 
 func newAssetFromString(in string) (out Asset, err error) {
 
-	// special case for "0 " which is a valid representation of an empty Asset
-	if strings.TrimSpace(in) == "0" {
-		return Asset{}, nil
-	}
-
 	integralPart, decimalPart, symbolPart, err := splitAsset(in)
 	if err != nil {
 		return out, err

--- a/types.go
+++ b/types.go
@@ -371,6 +371,10 @@ func (s Symbol) String() string {
 	return fmt.Sprintf("%d,%s", s.Precision, s.Symbol)
 }
 
+func (s Symbol) IsZero() bool {
+	return s.Symbol == "" && s.Precision == 0 && s.symbolCode == 0
+}
+
 func (s *Symbol) UnmarshalJSON(data []byte) error {
 	var str string
 	err := json.Unmarshal(data, &str)
@@ -465,17 +469,17 @@ func NewAsset(in string) (out Asset, err error) {
 	return NewAssetFromString(in)
 }
 
-// NewAssetFromString reads a string an decode it to an eos.Asset
-// structure if possible. The input must contains an amount and
-// a symbol. The precision is inferred based on the actual number
-// of decimals present.
+// NewAssetFromString reads a string and decodes it to an eos.Asset
+// structure if possible. The input must contain an amount and
+// a symbol, unless an empty asset is given in the form of "0".
+// The precision is inferred based on the actual number of decimals present.
 func NewAssetFromString(in string) (out Asset, err error) {
 	out, err = newAssetFromString(in)
 	if err != nil {
 		return out, err
 	}
 
-	if out.Symbol.Symbol == "" {
+	if out.Symbol.Symbol == "" && !out.IsZero() {
 		return out, fmt.Errorf("invalid format %q, expected an amount and a currency symbol", in)
 	}
 
@@ -527,6 +531,12 @@ func NewFixedSymbolAssetFromString(symbol Symbol, input string) (out Asset, err 
 }
 
 func newAssetFromString(in string) (out Asset, err error) {
+
+	// special case for "0 " which is a valid representation of an empty Asset
+	if strings.TrimSpace(in) == "0" {
+		return Asset{}, nil
+	}
+
 	integralPart, decimalPart, symbolPart, err := splitAsset(in)
 	if err != nil {
 		return out, err
@@ -590,6 +600,10 @@ func splitAssetAmount(input string) (integralPart, decimalPart string, err error
 	}
 
 	return
+}
+
+func (a *Asset) IsZero() bool {
+	return a.Amount == 0 && a.Symbol.IsZero()
 }
 
 func (a *Asset) UnmarshalJSON(data []byte) error {

--- a/types_test.go
+++ b/types_test.go
@@ -655,7 +655,7 @@ func TestNewAssetFromString(t *testing.T) {
 		{"0.1 TEST", 1, 1, "TEST", nil},
 		{".1 TEST", 1, 1, "TEST", nil},
 		{"0", 0, 0, "", nil},
-		{"  0  ", 0, 0, "", nil},
+		{"0 ", 0, 0, "", nil},
 
 		{"", 0, 0, "", errors.New("input cannot be empty")},
 		{"1", 0, 0, "", errors.New("invalid format \"1\", expected an amount and a currency symbol")},

--- a/types_test.go
+++ b/types_test.go
@@ -654,8 +654,11 @@ func TestNewAssetFromString(t *testing.T) {
 		{"1.0001 TEST", 10001, 4, "TEST", nil},
 		{"0.1 TEST", 1, 1, "TEST", nil},
 		{".1 TEST", 1, 1, "TEST", nil},
+		{"0", 0, 0, "", nil},
+		{"  0  ", 0, 0, "", nil},
 
 		{"", 0, 0, "", errors.New("input cannot be empty")},
+		{"1", 0, 0, "", errors.New("invalid format \"1\", expected an amount and a currency symbol")},
 		{".00.001", 0, 0, "", errors.New(`invalid asset amount ".00.001", expected amount to have at most a single dot`)},
 		{"1 ABCDEFGH", 0, 0, "", errors.New(`invalid asset "1 ABCDEFGH", symbol should have less than 7 characters`)},
 		{"1 A AND B", 0, 0, "", errors.New(`invalid asset "1 A AND B", expecting an amount alone or an amount and a currency symbol`)},


### PR DESCRIPTION
<!-- Optional  -->
## Background

It seems `"0 "` is a valid representation of an empty asset. See for example:

```
curl -s --location 'jungle4.api.eosnation.io/v1/chain/get_account' --header 'Content-Type: application/json' --data '{ "account_name": "eosnationftw" }' | jq .voter_info.reserved3
"0 "
```

Using eos-go on the `get_account` API endpoint will likely result in a panic.

## Summary

Changed `NewAssetFromString(in string)` so it will only check the symbol code if the Asset is not zero.   

## Note
<!--- Add More if you need. -->

## Checklist

- [ ] Backward compatible?
- [ ] Test enough in your local environment?
- [ ] Add related test cases?
