### PR TITLE
decoder: Fix timestamps tests

### DIFF
--- a/init_test.go
+++ b/init_test.go
@@ -1,9 +1,13 @@
 package eos
 
 import (
+	"time"
+
 	"github.com/streamingfast/logging"
 )
 
 func init() {
 	logging.InstantiateLoggers()
+
+	time.Local, _ = time.LoadLocation("America/New_York")
 }


### PR DESCRIPTION
<!-- Optional  -->
## Background
Some tests relies on a fixed timezone. making those tests fail on systems that are configured differently.

## Summary
These changes fixes those tests by comparing dates in UTC or setting the timezone temporary in the code. 

## Note
Not sure if this is the correct approach. Maybe the source problem is that the decoder should parse dates as UTC? As far as i know, all time/dates are in UTC in EOS.

## Checklist

- [x] Backward compatible?
- [x] Test enough in your local environment?
- [x] Add related test cases?
