### PR TITLE
Update abiencoder.go for compatible with double quoted string to number.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Unreleased
 
+* Changed valueToInt, valueToUint, valueToFload function in abiencode.go for compatible with double quoted string to number.
 * Changed `NewAssetFromString` validation to allow parsing of empty assets
 * Added `action_trace_v1` field
 * Added `AsTime` helper functions to convert `TimePoint` and `TimePointSec` to `time.Time`

--- a/abiencoder.go
+++ b/abiencoder.go
@@ -399,6 +399,7 @@ func (a *ABI) writeField(binaryEncoder *Encoder, fieldName string, fieldType str
 }
 
 func valueToInt(fieldName string, value gjson.Result, bitSize int) (int64, error) {
+	// Compatible with conversion of quoted strings to int
 	i, err := strconv.ParseInt(strings.Trim(value.Raw, `"`), 10, bitSize)
 	if err != nil {
 		return i, fmt.Errorf("writing field: [%s] type int%d : %w", fieldName, bitSize, err)
@@ -407,6 +408,7 @@ func valueToInt(fieldName string, value gjson.Result, bitSize int) (int64, error
 }
 
 func valueToUint(fieldName string, value gjson.Result, bitSize int) (uint64, error) {
+	// Compatible with conversion of quoted strings to uint
 	i, err := strconv.ParseUint(strings.Trim(value.Raw, `"`), 10, bitSize)
 	if err != nil {
 		return i, fmt.Errorf("writing field: [%s] type uint%d : %w", fieldName, bitSize, err)
@@ -424,7 +426,7 @@ func valueToFloat(fieldName string, value gjson.Result, bitSize int) (float64, e
 		return math.NaN(), nil
 	default:
 	}
-
+	// Compatible with conversion of quoted strings to float
 	f, err := strconv.ParseFloat(strings.Trim(value.Raw, `"`), bitSize)
 	if err != nil {
 		return f, fmt.Errorf("writing field: [%s] type float%d : %w", fieldName, bitSize, err)

--- a/abiencoder.go
+++ b/abiencoder.go
@@ -399,7 +399,14 @@ func (a *ABI) writeField(binaryEncoder *Encoder, fieldName string, fieldType str
 }
 
 func valueToInt(fieldName string, value gjson.Result, bitSize int) (int64, error) {
-	i, err := strconv.ParseInt(value.Raw, 10, bitSize)
+	s := value.Raw
+	if len(s) > 0 && s[0] == '"' {
+		s = s[1:]
+	}
+	if len(s) > 0 && s[len(s)-1] == '"' {
+		s = s[:len(s)-1]
+	}
+	i, err := strconv.ParseInt(s, 10, bitSize)
 	if err != nil {
 		return i, fmt.Errorf("writing field: [%s] type int%d : %w", fieldName, bitSize, err)
 	}
@@ -407,7 +414,14 @@ func valueToInt(fieldName string, value gjson.Result, bitSize int) (int64, error
 }
 
 func valueToUint(fieldName string, value gjson.Result, bitSize int) (uint64, error) {
-	i, err := strconv.ParseUint(value.Raw, 10, bitSize)
+	s := value.Raw
+	if len(s) > 0 && s[0] == '"' {
+		s = s[1:]
+	}
+	if len(s) > 0 && s[len(s)-1] == '"' {
+		s = s[:len(s)-1]
+	}
+	i, err := strconv.ParseUint(s, 10, bitSize)
 	if err != nil {
 		return i, fmt.Errorf("writing field: [%s] type uint%d : %w", fieldName, bitSize, err)
 	}
@@ -415,7 +429,14 @@ func valueToUint(fieldName string, value gjson.Result, bitSize int) (uint64, err
 }
 
 func valueToFloat(fieldName string, value gjson.Result, bitSize int) (float64, error) {
-	switch value.Raw {
+	s := value.Raw
+	if len(s) > 0 && s[0] == '"' {
+		s = s[1:]
+	}
+	if len(s) > 0 && s[len(s)-1] == '"' {
+		s = s[:len(s)-1]
+	}
+	switch s {
 	case "inf":
 		return math.Inf(1), nil
 	case "-inf":
@@ -425,7 +446,7 @@ func valueToFloat(fieldName string, value gjson.Result, bitSize int) (float64, e
 	default:
 	}
 
-	f, err := strconv.ParseFloat(value.Raw, bitSize)
+	f, err := strconv.ParseFloat(s, bitSize)
 	if err != nil {
 		return f, fmt.Errorf("writing field: [%s] type float%d : %w", fieldName, bitSize, err)
 	}

--- a/abiencoder.go
+++ b/abiencoder.go
@@ -399,14 +399,7 @@ func (a *ABI) writeField(binaryEncoder *Encoder, fieldName string, fieldType str
 }
 
 func valueToInt(fieldName string, value gjson.Result, bitSize int) (int64, error) {
-	s := value.Raw
-	if len(s) > 0 && s[0] == '"' {
-		s = s[1:]
-	}
-	if len(s) > 0 && s[len(s)-1] == '"' {
-		s = s[:len(s)-1]
-	}
-	i, err := strconv.ParseInt(s, 10, bitSize)
+	i, err := strconv.ParseInt(strings.Trim(value.Raw, `"`), 10, bitSize)
 	if err != nil {
 		return i, fmt.Errorf("writing field: [%s] type int%d : %w", fieldName, bitSize, err)
 	}
@@ -414,14 +407,7 @@ func valueToInt(fieldName string, value gjson.Result, bitSize int) (int64, error
 }
 
 func valueToUint(fieldName string, value gjson.Result, bitSize int) (uint64, error) {
-	s := value.Raw
-	if len(s) > 0 && s[0] == '"' {
-		s = s[1:]
-	}
-	if len(s) > 0 && s[len(s)-1] == '"' {
-		s = s[:len(s)-1]
-	}
-	i, err := strconv.ParseUint(s, 10, bitSize)
+	i, err := strconv.ParseUint(strings.Trim(value.Raw, `"`), 10, bitSize)
 	if err != nil {
 		return i, fmt.Errorf("writing field: [%s] type uint%d : %w", fieldName, bitSize, err)
 	}
@@ -429,14 +415,7 @@ func valueToUint(fieldName string, value gjson.Result, bitSize int) (uint64, err
 }
 
 func valueToFloat(fieldName string, value gjson.Result, bitSize int) (float64, error) {
-	s := value.Raw
-	if len(s) > 0 && s[0] == '"' {
-		s = s[1:]
-	}
-	if len(s) > 0 && s[len(s)-1] == '"' {
-		s = s[:len(s)-1]
-	}
-	switch s {
+	switch value.Raw {
 	case "inf":
 		return math.Inf(1), nil
 	case "-inf":
@@ -446,7 +425,7 @@ func valueToFloat(fieldName string, value gjson.Result, bitSize int) (float64, e
 	default:
 	}
 
-	f, err := strconv.ParseFloat(s, bitSize)
+	f, err := strconv.ParseFloat(strings.Trim(value.Raw, `"`), bitSize)
 	if err != nil {
 		return f, fmt.Errorf("writing field: [%s] type float%d : %w", fieldName, bitSize, err)
 	}


### PR DESCRIPTION
Because the params of number with quotation marks are supported on the command of cleos push action.