### PR TITLE
fix(p2p): handshake signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Fixed ABI encoder for `SymbolCode` type.
 
+* Fixed P2P HandshakeMessage signature generation
+
 #### Deprecated
 
 ### [**0.10.2**](https://github.com/eoscanada/eos-go/releases/tag/v0.10.2) (January 19th, 2022)


### PR DESCRIPTION
<!-- Optional  -->
## Background
The handshake resulted in invalid signature and the program crashes with the error
```
p2p message, invalid signature: the inner signature structure must be present, was nil
```
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Summary
This PR changes:
* the public key used in the HandshakeMessage from hardcoded to randomly generated
* the signature is now generated from the private key
* the handshake token to the the sha256 checksum of the handshake's timestamp

<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->

## Note
<!--- Add More if you need. -->

## Checklist

- [ ] Backward compatible?
- [x] Test enough in your local environment?
- [ ] Add related test cases?