### PR TITLE
Add next key to get table rows resp

### DIFF
--- a/responses.go
+++ b/responses.go
@@ -283,8 +283,9 @@ type GetTableRowsRequest struct {
 }
 
 type GetTableRowsResp struct {
-	More bool            `json:"more"`
-	Rows json.RawMessage `json:"rows"` // defer loading, as it depends on `JSON` being true/false.
+	More    bool            `json:"more"`
+	NextKey string          `json:"next_key"`
+	Rows    json.RawMessage `json:"rows"` // defer loading, as it depends on `JSON` being true/false.
 }
 
 func (resp *GetTableRowsResp) JSONToStructs(v interface{}) error {


### PR DESCRIPTION
<!-- Optional  -->
## Background
A attribute is missing in the get table row response, details here https://github.com/eoscanada/eos-go/issues/175

## Summary
Simply de-serialize this attribute also

## Note
<!--- Add More if you need. -->

## Checklist

- [x] Backward compatible?
- [x] Test enough in your local environment?
- [ ] Add related test cases?
