### PR TITLE
improve the error handling when decoding table rows with variant types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Fixed
 
+* Improved the error handling when decoding table rows with variant types.
+
 * Fixed decoding of table rows with variant types.
 
 * Fixed serialization of `map[K]V` when using `eos.MarshalBinary` so that ordering in which the keys are serialized is in lexicographical order, just like JSON serialization.

--- a/abidecoder.go
+++ b/abidecoder.go
@@ -83,7 +83,9 @@ func (a *ABI) decode(binaryDecoder *Decoder, structName string) (map[string]inte
 	if variant := a.VariantForName(structName); variant != nil {
 		out, err := binaryDecoder.ReadUvarint32()
 		if err != nil {
-			zlog.Error("error reading variant", zap.Error(err))
+			return nil, fmt.Errorf("error reading variant: %v", err)
+		} else if int(out) >= len(variant.Types) { // we shouldn't trust any data from chain, so we double-check the slice bounds
+			return nil, fmt.Errorf("invalid variant type, index is out of bound: %d", out)
 		}
 		structName = variant.Types[out]
 	}

--- a/abidecoder.go
+++ b/abidecoder.go
@@ -81,13 +81,13 @@ func (a *ABI) decode(binaryDecoder *Decoder, structName string) (map[string]inte
 	}
 
 	if variant := a.VariantForName(structName); variant != nil {
-		out, err := binaryDecoder.ReadUvarint32()
+		variantIndex, err := binaryDecoder.ReadUvarint32()
 		if err != nil {
-			return nil, fmt.Errorf("error reading variant: %v", err)
-		} else if int(out) >= len(variant.Types) { // we shouldn't trust any data from chain, so we double-check the slice bounds
-			return nil, fmt.Errorf("invalid variant type, index is out of bound: %d", out)
+			return nil, fmt.Errorf("error reading variant: %w", err)
+		} else if int(variantIndex) >= len(variant.Types) {
+			return nil, fmt.Errorf("variant type index is unknown, got type index %d, know up to index %d", variantIndex, len(variant.Types)-1)
 		}
-		structName = variant.Types[out]
+		structName, _ = a.TypeNameForNewTypeName(variant.Types[variantIndex])
 	}
 
 	structure := a.StructForName(structName)


### PR DESCRIPTION
## Summary

This PR adds some improvements and fixes to the error handling when decoding variant table rows. It adds a missing return on error, adds a manual boundary check for the variant array and adds support for aliases. 


## Checklist

- [x] Backward compatible?
- [x] Test enough in your local environment?
- [ ] Add related test cases?
